### PR TITLE
Add MQTT Home Assistant discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,18 @@ The web interface allows you to:
 
 This feature is under development, and functionality will be expanded in the future.
 
+## Home Assistant Discovery
+
+When MQTT is enabled (`#define MQTT` in `include/user_config.h`) the firmware publishes Home Assistant discovery messages for every blind defined in `extras/1W.json` as soon as the MQTT connection is established.
+
+Each blind configuration is sent to the topic `homeassistant/cover/<id>/config` where `<id>` is the hexadecimal address from `1W.json`.
+
+Example payload for `B60D1A`:
+
+```json
+{"name":"IZY1","command_topic":"iown/B60D1A/set","state_topic":"iown/B60D1A/state","unique_id":"B60D1A","payload_open":"OPEN","payload_close":"CLOSE","payload_stop":"STOP","device_class":"blind"}
+```
+
+Configure your MQTT broker settings in `include/user_config.h` (`MQTT_SERVER`, `MQTT_USER`, `MQTT_PASSWD`). After boot and connection, Home Assistant should automatically discover the covers.
+
 #### **License**

--- a/include/interact.h
+++ b/include/interact.h
@@ -71,6 +71,9 @@ using Tokens = std::vector<std::string>;
 inline AsyncMqttClient mqttClient;
 inline TimerHandle_t mqttReconnectTimer;
 
+void publishDiscovery(const std::string &id, const std::string &name);
+void handleMqttConnect();
+
 inline  void connectToMqtt() {
     Serial.println("Connecting to MQTT...");
     // //        esp_log_level_set("mqtt_client", ESP_LOG_VERBOSE);
@@ -103,6 +106,7 @@ inline void onMqttConnect(bool sessionPresent) {
   mqttClient.subscribe("iown/heatState", 0); 
 
   mqttClient.publish("iown/Frame", 0, false, R"({"cmd": "powerOn", "_data": "Gateway"})", 38);
+  handleMqttConnect();
   // Serial.println("Publishing at QoS 0");
   // uint16_t packetIdPub1 = mqttClient.publish("test/lol", 1, true, "test 2");
   // Serial.print("Publishing at QoS 1, packetId: ");

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -20,6 +20,8 @@
 #include <interact.h>
 #include <iohcDevice.h>
 #include <vector>
+#include <string>
+#include <utility>
 
 #define IOHC_1W_REMOTE  "/1W.json"
 
@@ -53,6 +55,8 @@ namespace IOHC {
 //        void scanDump() override { }
 
         static void forgePacket(iohcPacket* packet, uint16_t typn);
+
+        std::vector<std::pair<std::string, std::string>> listRemotes() const;
 
     private:
         iohcRemote1W();

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -19,6 +19,33 @@
 #include <iohcOtherDevice2W.h>
 #include <interact.h>
 
+#if defined(MQTT)
+void publishDiscovery(const std::string &id, const std::string &name) {
+    JsonDocument doc;
+    doc["name"] = name;
+    doc["command_topic"] = "iown/" + id + "/set";
+    doc["state_topic"] = "iown/" + id + "/state";
+    doc["unique_id"] = id;
+    doc["payload_open"] = "OPEN";
+    doc["payload_close"] = "CLOSE";
+    doc["payload_stop"] = "STOP";
+    doc["device_class"] = "blind";
+
+    std::string payload;
+    size_t len = serializeJson(doc, payload);
+
+    std::string topic = "homeassistant/cover/" + id + "/config";
+    mqttClient.publish(topic.c_str(), 0, true, payload.c_str(), len);
+}
+
+void handleMqttConnect() {
+    auto remotes = IOHC::iohcRemote1W::getInstance()->listRemotes();
+    for (const auto &p : remotes) {
+        publishDiscovery(p.first, p.second);
+    }
+}
+#endif
+
 namespace Cmd {
 /**
  * The function `createCommands()` initializes and adds various command handlers for controlling

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -530,7 +530,7 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
     }
    bool iohcRemote1W::save() {
         fs::File f = LittleFS.open(IOHC_1W_REMOTE, "w+");
-        JsonDocument doc; 
+        JsonDocument doc;
         for (const auto&r: remotes) {
             // jobj["key"] = bytesToHexString(_key, sizeof(_key));
 //            JsonObject jobj = doc.createNestedObject(bytesToHexString(r.node, sizeof(r.node)));
@@ -562,5 +562,14 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
         f.close();
 
         return true;
+    }
+
+    std::vector<std::pair<std::string, std::string>> iohcRemote1W::listRemotes() const {
+        std::vector<std::pair<std::string, std::string>> result;
+        result.reserve(remotes.size());
+        for (const auto &r : remotes) {
+            result.emplace_back(bytesToHexString(r.node, sizeof(r.node)), r.description);
+        }
+        return result;
     }
 }


### PR DESCRIPTION
## Summary
- expose remote list from `iohcRemote1W`
- implement `publishDiscovery` and helper to publish HA discovery
- send discovery after MQTT connect
- document Home Assistant integration

## Testing
- `pip install platformio`
- `pio check -e HeltecLoraV2ESP32` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68619ba4d56c8326a79ab90e95a08483