### PR TITLE
Improve MQTT command handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,8 @@ Example payload for `B60D1A`:
 
 Configure your MQTT broker settings in `include/user_config.h` (`MQTT_SERVER`, `MQTT_USER`, `MQTT_PASSWD`). After boot and connection, Home Assistant should automatically discover the covers.
 
+Once discovery is complete you can control a blind by publishing `OPEN`, `CLOSE`
+or `STOP` to `iown/<id>/set`. The firmware listens on these topics and issues the
+corresponding command to the device.
+
 #### **License**

--- a/include/interact.h
+++ b/include/interact.h
@@ -22,9 +22,10 @@
 #include <board-config.h>
 #include <user_config.h>
 
-#include <vector> 
-#include <sstream> 
+#include <vector>
+#include <sstream>
 #include <cstring>
+#include <algorithm>
 
 extern "C" {
 	#include "freertos/FreeRTOS.h"
@@ -168,27 +169,48 @@ inline void onMqttConnect(bool sessionPresent) {
   inline void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
     if (topic[0] == '\0') return;
 
+    std::string topicStr(topic);
+    std::string payloadStr(payload, len);
+    Serial.printf("Received MQTT %s %s %d\n", topicStr.c_str(), payloadStr.c_str(), len);
+
+    // Handle Home Assistant cover commands (iown/<id>/set)
+    if (topicStr.rfind("iown/", 0) == 0 && topicStr.find("/set", 5) != std::string::npos) {
+      std::string id = topicStr.substr(5, topicStr.find("/set", 5) - 5);
+      const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
+      auto it = std::find_if(remotes.begin(), remotes.end(), [&](const auto &r){
+        return bytesToHexString(r.node, sizeof(r.node)) == id;
+      });
+      if (it != remotes.end()) {
+        Tokens t;
+        std::transform(payloadStr.begin(), payloadStr.end(), payloadStr.begin(), ::tolower);
+        t.push_back(payloadStr);
+        t.push_back(it->description);
+
+        Serial.printf("MQTT exec %s on %s (%s)\n", payloadStr.c_str(), it->description.c_str(), id.c_str());
+
+        if (payloadStr == "open") IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Open, &t);
+        else if (payloadStr == "close") IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Close, &t);
+        else if (payloadStr == "stop") IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Stop, &t);
+        else if (payloadStr == "vent") IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Vent, &t);
+        else if (payloadStr == "force") IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::ForceOpen, &t);
+        else Serial.printf("*> MQTT Unknown %s <*\n", payloadStr.c_str());
+      } else {
+        Serial.printf("*> MQTT Unknown device %s <*\n", id.c_str());
+      }
+      return;
+    }
+
     JsonDocument doc;
-
-	  payload[len] = '\0';
-
-    Serial.printf("Received MQTT %s %s %d\n", topic, payload, len);
-
     if (deserializeJson(doc, payload) != DeserializationError::Ok) {
       Serial.println(F("Failed to parse JSON"));
       return;
     }
 
     const char *data = doc["_data"];
-
-    // Calcul de la taille du tampon nécessaire
-    size_t bufferSize = strlen(topic) + len + 7; // +5 word "MQTT " +2 pour l'espace et le caractère nul de fin de chaîne
-    // Allouer le tampon
+    size_t bufferSize = strlen(topic) + (data ? strlen(data) : 0) + 7;
     char message[bufferSize];
-    if (len == 0) {snprintf(message, sizeof(message), "MQTT %s", topic); }
-    // Utiliser snprintf pour éviter les dépassements de tampon
+    if (!data) snprintf(message, sizeof(message), "MQTT %s", topic);
     else snprintf(message, sizeof(message), "MQTT %s %s", topic, data);
-      
     mqttFuncHandler(message);
   }
 

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -44,6 +44,9 @@ void handleMqttConnect() {
     for (const auto &r : remotes) {
         std::string id = bytesToHexString(r.node, sizeof(r.node));
         publishDiscovery(id, r.description);
+        std::string t = "iown/" + id + "/set";
+        mqttClient.subscribe(t.c_str(), 0);
+        Serial.printf("Subscribed to %s\n", t.c_str());
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- log when subscribing to cover command topics
- handle MQTT payloads without modifying the original buffer
- avoid strlen on a null pointer

## Testing
- `g++ -fsyntax-only -std=c++17 -Iinclude -DMQTT -DESP32 src/interact.cpp` *(fails: LittleFS.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6863895fa508832692c0c999e6d59413