### PR TITLE
Fix MQTT topic case handling

### DIFF
--- a/include/interact.h
+++ b/include/interact.h
@@ -178,6 +178,7 @@ inline void onMqttConnect(bool sessionPresent) {
     // Handle Home Assistant cover commands (iown/<id>/set)
     if (topicStr.rfind("iown/", 0) == 0 && topicStr.find("/set", 5) != std::string::npos) {
       std::string id = topicStr.substr(5, topicStr.find("/set", 5) - 5);
+      std::transform(id.begin(), id.end(), id.begin(), ::tolower);
       const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
       auto it = std::find_if(remotes.begin(), remotes.end(), [&](const auto &r){
         return bytesToHexString(r.node, sizeof(r.node)) == id;


### PR DESCRIPTION
## Summary
- normalize cover IDs from MQTT topics to lowercase before comparison

## Testing
- `pio check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863be5b393483268836defcae2fd199