### PR TITLE
Fix include order and avoid circular headers

### DIFF
--- a/include/interact.h
+++ b/include/interact.h
@@ -40,6 +40,11 @@ extern "C" {
 #endif
 
 #include <utils.h>
+#include <tokens.h>
+
+namespace IOHC {
+  class iohcRemote1W;
+}
 
 #if defined(ESP32)
   #include <TickerUsESP32.h>
@@ -48,8 +53,6 @@ extern "C" {
 
 inline TimerHandle_t wifiReconnectTimer;
 inline WiFiClient wifiClient;                 // Create an ESP32 WiFiClient class to connect to the MQTT server
-
-using Tokens = std::vector<std::string>;
 
   inline void tokenize(std::string const &str, const char delim, Tokens &out) {
       // construct a stream from the string 
@@ -178,6 +181,7 @@ inline void onMqttConnect(bool sessionPresent) {
     // Handle Home Assistant cover commands (iown/<id>/set)
     if (topicStr.rfind("iown/", 0) == 0 && topicStr.find("/set", 5) != std::string::npos) {
       std::string id = topicStr.substr(5, topicStr.find("/set", 5) - 5);
+      std::transform(id.begin(), id.end(), id.begin(), ::tolower);
       const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
       auto it = std::find_if(remotes.begin(), remotes.end(), [&](const auto &r){
         return bytesToHexString(r.node, sizeof(r.node)) == id;

--- a/include/iohcCozyDevice2W.h
+++ b/include/iohcCozyDevice2W.h
@@ -17,12 +17,12 @@
 #ifndef COZY_2W_DEVICE_H
 #define COZY_2W_DEVICE_H
 
-#include <interact.h>
 #include <string>
 #include <iohcRadio.h>
 #include <iohcDevice.h>
 #include <map>
 #include <vector>
+#include <tokens.h>
 
 #define COZY_2W_FILE  "/Cozy2W.json"
 

--- a/include/iohcOtherDevice2W.h
+++ b/include/iohcOtherDevice2W.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 #include <iohcDevice.h>
-#include <interact.h>
+#include <tokens.h>
 
 #define OTHER_2W_FILE  "/Other2W.json"
 

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -17,9 +17,9 @@
 #ifndef IOHC_1W_DEVICE_H
 #define IOHC_1W_DEVICE_H
 
-#include <interact.h>
 #include <iohcDevice.h>
 #include <vector>
+#include <tokens.h>
 
 #define IOHC_1W_REMOTE  "/1W.json"
 

--- a/include/tokens.h
+++ b/include/tokens.h
@@ -1,0 +1,6 @@
+#ifndef TOKENS_H
+#define TOKENS_H
+#include <vector>
+#include <string>
+using Tokens = std::vector<std::string>;
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,6 @@
 #include <board-config.h>
 #include <user_config.h>
 
-#include <interact.h>
 #include <crypto2Wutils.h>
 #include <iohcCryptoHelpers.h>
 #include <iohcRadio.h>
@@ -28,6 +27,7 @@
 #include <iohcRemote1W.h>
 #include <iohcCozyDevice2W.h>
 #include <iohcOtherDevice2W.h>
+#include <interact.h>
 
 #include <web_server_handler.h>
 #include "LittleFS.h"


### PR DESCRIPTION
## Summary
- move `Tokens` alias to new `tokens.h`
- include the new header in device classes
- include device headers before `interact.h` in `main.cpp`

## Testing
- `pio check` *(failed: `pio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863be5b393483268836defcae2fd199