### PR TITLE
Prevent crash from failed JSON allocations

### DIFF
--- a/src/web_server_handler.cpp
+++ b/src/web_server_handler.cpp
@@ -24,6 +24,10 @@ const int numDevices = sizeof(devices) / sizeof(Device);
 
 void handleApiDevices(AsyncWebServerRequest *request) {
     AsyncJsonResponse* response = new AsyncJsonResponse();
+    if(!response){
+        request->send(500, "text/plain", "Out of memory");
+        return;
+    }
     JsonArray root = response->getRoot().to<JsonArray>();
 
     for (int i = 0; i < numDevices; i++) {
@@ -64,6 +68,10 @@ void handleApiCommand(AsyncWebServerRequest *request, JsonVariant &json) {
     bool success = true;
 
     AsyncJsonResponse* response = new AsyncJsonResponse();
+    if(!response){
+        request->send(500, "application/json", "{\"success\":false,\"message\":\"OOM\"}");
+        return;
+    }
     JsonObject root = response->getRoot().to<JsonObject>();
     root["success"] = success;
     root["message"] = message;


### PR DESCRIPTION
## Summary
- check pointers returned from `new AsyncJsonResponse` to ensure the server has
  enough memory to build a JSON reply

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866ee82b3cc8326b2bfaa84a428931d