### PR TITLE
Set board specific I2C pins

### DIFF
--- a/include/board-config.h
+++ b/include/board-config.h
@@ -41,6 +41,18 @@
 #define RADIO_BUSY_PIN      32
 #endif
 
+// I2C pin definitions for OLED or peripherals
+#if defined(LILYGO)
+#define I2C_SDA_PIN 21
+#define I2C_SCL_PIN 22
+#elif defined(HELTEC)
+#define I2C_SDA_PIN 4
+#define I2C_SCL_PIN 15
+#else
+#define I2C_SDA_PIN 21
+#define I2C_SCL_PIN 22
+#endif
+
 // OK LilyGo Wifi ESP32 Lora v2.1.6
 // https://github.com/LilyGO/ESP32-Paxcounter/blob/master/src/hal/ttgov2.h 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,10 +38,10 @@
 #include <Wire.h>
 //#include "HT_SSD1306Wire.h"
 
-// OLED configuration for Heltec WiFi LoRa 32 V2
+// OLED configuration
 #define OLED_ADDRESS 0x3c
-#define OLED_SDA     4
-#define OLED_SCL     15
+#define OLED_SDA     I2C_SDA_PIN
+#define OLED_SCL     I2C_SCL_PIN
 #define OLED_RST     16
 #define SCREEN_WIDTH 128 // OLED display width
 #define SCREEN_HEIGHT 64 // OLED display height
@@ -87,7 +87,7 @@ using namespace IOHC;
 void setup() {
     Serial.begin(115200);
     
-    Wire.begin(OLED_SDA, OLED_SCL);  // SDA = 21, SCL = 22 (ESP32 default, change if needed)
+    Wire.begin(OLED_SDA, OLED_SCL);  // pins defined per board in board-config.h
 
     // Initialize display
     if (!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {


### PR DESCRIPTION
## Summary
- define I2C pins in `board-config.h` for Heltec and LilyGo boards
- use those definitions in `main.cpp`

## Testing
- `pio check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f4eefca88326b792e754defdf39c