### PR TITLE
Add MQTT availability support

### DIFF
--- a/include/interact.h
+++ b/include/interact.h
@@ -74,9 +74,11 @@ inline WiFiClient wifiClient;                 // Create an ESP32 WiFiClient clas
 #if defined(MQTT)
 inline AsyncMqttClient mqttClient;
 inline TimerHandle_t mqttReconnectTimer;
+inline TimerHandle_t heartbeatTimer;
 
 void publishDiscovery(const std::string &id, const std::string &name);
 void handleMqttConnect();
+void publishHeartbeat(TimerHandle_t timer);
 
 inline  void connectToMqtt() {
     Serial.println("Connecting to MQTT...");


### PR DESCRIPTION
## Summary
- include availability topic in Home Assistant discovery payload
- add heartbeat timer that refreshes availability every minute
- expire MQTT state after 120 seconds

## Testing
- `pio check` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68682111ae2083268e1704beba5277f9