### PR TITLE
Fix MQTT Last Will handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Each blind configuration is sent to the topic `homeassistant/cover/<id>/config` 
 Example payload for `B60D1A`:
 
 ```json
-{"name":"IZY1","command_topic":"iown/B60D1A/set","state_topic":"iown/B60D1A/state","unique_id":"B60D1A","payload_open":"OPEN","payload_close":"CLOSE","payload_stop":"STOP","device_class":"blind"}
+{"name":"IZY1","command_topic":"iown/B60D1A/set","state_topic":"iown/B60D1A/state","unique_id":"B60D1A","payload_open":"OPEN","payload_close":"CLOSE","payload_stop":"STOP","device_class":"blind","availability_topic":"iown/status"}
 ```
 
 Configure your MQTT broker settings in `include/user_config.h` (`MQTT_SERVER`, `MQTT_USER`, `MQTT_PASSWD`). After boot and connection, Home Assistant should automatically discover the covers.
@@ -100,5 +100,10 @@ Configure your MQTT broker settings in `include/user_config.h` (`MQTT_SERVER`, `
 Once discovery is complete you can control a blind by publishing `OPEN`, `CLOSE`
 or `STOP` to `iown/<id>/set`. The firmware listens on these topics and issues the
 corresponding command to the device.
+
+The gateway publishes `online` every minute to `iown/status` and has a Last Will
+configured to send `offline` on the same topic if it disconnects unexpectedly.
+Home Assistant uses this message to mark all covers as unavailable when the
+gateway goes offline.
 
 #### **License**

--- a/include/interact.h
+++ b/include/interact.h
@@ -75,6 +75,7 @@ inline WiFiClient wifiClient;                 // Create an ESP32 WiFiClient clas
 inline AsyncMqttClient mqttClient;
 inline TimerHandle_t mqttReconnectTimer;
 inline TimerHandle_t heartbeatTimer;
+constexpr char AVAILABILITY_TOPIC[] = "iown/status";
 
 void publishDiscovery(const std::string &id, const std::string &name);
 void handleMqttConnect();
@@ -94,6 +95,7 @@ inline  void connectToMqtt() {
     // esp_mqtt_client_handle_t client = esp_mqtt_client_init(&mqtt_cfg);
     // esp_mqtt_client_reconnect(client);
     // //    esp_mqtt_client_start(client);
+    mqttClient.setWill(AVAILABILITY_TOPIC, 0, true, "offline");
     mqttClient.connect();
   }
 inline void onMqttConnect(bool sessionPresent) {

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -26,7 +26,7 @@ void publishDiscovery(const std::string &id, const std::string &name) {
     doc["name"] = name;
     doc["command_topic"] = "iown/" + id + "/set";
     doc["state_topic"] = "iown/" + id + "/state";
-    doc["availability_topic"] = "iown/" + id + "/availability";
+    doc["availability_topic"] = AVAILABILITY_TOPIC;
     doc["payload_available"] = "online";
     doc["payload_not_available"] = "offline";
     doc["expire_after"] = 120;
@@ -41,17 +41,10 @@ void publishDiscovery(const std::string &id, const std::string &name) {
 
     std::string topic = "homeassistant/cover/" + id + "/config";
     mqttClient.publish(topic.c_str(), 0, true, payload.c_str(), len);
-    topic = "iown/" + id + "/availability";
-    mqttClient.setWill(topic.c_str(), 0, true, "offline"); 
 }
 
 void publishHeartbeat(TimerHandle_t) {
-    const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
-    for (const auto &r : remotes) {
-        std::string id = bytesToHexString(r.node, sizeof(r.node));
-        std::string topic = "iown/" + id + "/availability";
-        mqttClient.publish(topic.c_str(), 0, true, "online");
-    }
+    mqttClient.publish(AVAILABILITY_TOPIC, 0, true, "online");
 }
 
 void handleMqttConnect() {


### PR DESCRIPTION
## Summary
- configure a shared availability topic
- send `offline` via Last Will when the gateway disconnects
- adjust heartbeat to publish `online` on the same topic
- document MQTT availability topic in README

## Testing
- `platformio run -e HeltecLoraV2ESP32` *(fails: blocked by network)*

------
https://chatgpt.com/codex/tasks/task_e_6868349d63b88326b845759b8c100b89