### PR TITLE
Show 1W actions on transmit

### DIFF
--- a/include/oled_display.h
+++ b/include/oled_display.h
@@ -18,6 +18,6 @@ extern Adafruit_SSD1306 display;
 
 bool initDisplay();
 void displayIpAddress(IPAddress ip);
-void display1WAction(const uint8_t *remote, const char *action);
+void display1WAction(const uint8_t *remote, const char *action, const char *dir);
 
 #endif // OLED_DISPLAY_H

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -19,9 +19,28 @@
 #include <ArduinoJson.h>
 
 #include <iohcCryptoHelpers.h>
+#include <oled_display.h>
 
 namespace IOHC {
     iohcRemote1W* iohcRemote1W::_iohcRemote1W = nullptr;
+
+    static const char *remoteButtonToString(RemoteButton cmd) {
+        switch (cmd) {
+            case RemoteButton::Open: return "OPEN";
+            case RemoteButton::Close: return "CLOSE";
+            case RemoteButton::Stop: return "STOP";
+            case RemoteButton::Vent: return "VENT";
+            case RemoteButton::ForceOpen: return "FORCE";
+            case RemoteButton::Pair: return "PAIR";
+            case RemoteButton::Add: return "ADD";
+            case RemoteButton::Remove: return "REMOVE";
+            case RemoteButton::Mode1: return "MODE1";
+            case RemoteButton::Mode2: return "MODE2";
+            case RemoteButton::Mode3: return "MODE3";
+            case RemoteButton::Mode4: return "MODE4";
+            default: return "UNKNOWN";
+        }
+    }
 
     iohcRemote1W::iohcRemote1W() = default;
 
@@ -147,6 +166,7 @@ namespace IOHC {
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 //                }
                 _radioInstance->send(packets2send);
+                display1WAction(r.node, remoteButtonToString(cmd), "TX");
                 break;
             }
 
@@ -190,6 +210,7 @@ namespace IOHC {
 //                }
                 _radioInstance->send(packets2send);
                 //printf("\n");
+                display1WAction(r.node, remoteButtonToString(cmd), "TX");
                 break;
             }
 
@@ -232,6 +253,7 @@ namespace IOHC {
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 //                }
                 _radioInstance->send(packets2send);
+                display1WAction(r.node, remoteButtonToString(cmd), "TX");
                 break;
             }
            default: {
@@ -459,6 +481,7 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
                 }
                 _radioInstance->send(packets2send);
+                display1WAction(r.node, remoteButtonToString(cmd), "TX");
                 break;
 //            }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -434,7 +434,7 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
                     default: break;
                 }
                 doc["action"] = action;
-                display1WAction(iohc->payload.packet.header.source, action);
+                display1WAction(iohc->payload.packet.header.source, action, "RX");
             } else {
                 doc["type"] = "Other";
                 otherDevice2W->memorizeOther2W.memorizedCmd = iohc->payload.packet.header.cmd;

--- a/src/oled_display.cpp
+++ b/src/oled_display.cpp
@@ -39,12 +39,14 @@ void displayIpAddress(IPAddress ip) {
     display.display();
 }
 
-void display1WAction(const uint8_t *remote, const char *action) {
+void display1WAction(const uint8_t *remote, const char *action, const char *dir) {
     std::string id = bytesToHexString(remote, 3);
     display.clearDisplay();
     display.setTextSize(1);
     display.setTextColor(SSD1306_WHITE);
     display.setCursor(0, 0);
+    display.print(dir);
+    display.println(":");
     display.print("ID: ");
     display.println(id.c_str());
     display.print("Action: ");


### PR DESCRIPTION
## Summary
- add display direction so the OLED can show RX/TX
- show action direction when handling 1W packets

## Testing
- `pio check` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6868ea72970483269097b7d3c9ff5dad