### PR TITLE
Add MQTT state publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Configure your MQTT broker settings in `include/user_config.h` (`MQTT_SERVER`, `
 Once discovery is complete you can control a blind by publishing `OPEN`, `CLOSE`
 or `STOP` to `iown/<id>/set`. The firmware listens on these topics and issues the
 corresponding command to the device.
+When an `OPEN` or `CLOSE` command is received, it immediately publishes the new
+state (`open` or `closed`) to `iown/<id>/state` so Home Assistant can update the
+cover status.
 
 The gateway publishes `online` every minute to `iown/status` and has a Last Will
 configured to send `offline` on the same topic if it disconnects unexpectedly.

--- a/include/interact.h
+++ b/include/interact.h
@@ -243,9 +243,16 @@ inline void onMqttDisconnect(AsyncMqttClientDisconnectReason) {
         std::transform(payloadStr.begin(), payloadStr.end(), payloadStr.begin(), ::tolower);
         t.push_back(payloadStr);
         t.push_back(it->description);
+        std::string stateTopic = "iown/" + id + "/state";
 
-        if (payloadStr == "open") IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Open, &t);
-        else if (payloadStr == "close") IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Close, &t);
+        if (payloadStr == "open") {
+          IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Open, &t);
+          mqttClient.publish(stateTopic.c_str(), 0, true, "open");
+        }
+        else if (payloadStr == "close") {
+          IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Close, &t);
+          mqttClient.publish(stateTopic.c_str(), 0, true, "closed");
+        }
         else if (payloadStr == "stop") IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Stop, &t);
         else if (payloadStr == "vent") IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Vent, &t);
         else if (payloadStr == "force") IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::ForceOpen, &t);


### PR DESCRIPTION
## Summary
- send current blind state to Home Assistant when MQTT commands are received
- document automatic state updates in Home Assistant section

## Testing
- `pio check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692439d43883269354a1af365b5198