### PR TITLE
Fix retained MQTT command

### DIFF
--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -165,6 +165,8 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
             } else {
                 Serial.printf("*> MQTT Unknown %s <*\n", payloadStr.c_str());
             }
+            // Clear retained set message to avoid re-trigger on reconnect
+            mqttClient.publish(topicStr.c_str(), 0, true, "", 0);
         } else {
             Serial.printf("*> MQTT Unknown device %s <*\n", id.c_str());
         }


### PR DESCRIPTION
## Summary
- prevent set commands from being re-triggered after reconnecting by clearing retained messages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686a2eaa13448326ae12a172a9edad43