### PR TITLE
Add device names in config

### DIFF
--- a/extras/1W.json
+++ b/extras/1W.json
@@ -1,7 +1,57 @@
 {
-    "b60d1a":{"key":"2d36bd8b4d4fb1e1a1b3099b394d3a9e","sequence":"2410","type":[0,0],"manufacturer_id":2,"description":"IZY1"},
-    "b60d1b":{"key":"b794883327810507c2a5419eeeae54b4","sequence":"08d7","type":[0,0],"manufacturer_id":2,"description":"IZY2"},
-    "e8e150":{"key":"77999e593262e207c8f992904ec4c4f2","sequence":"08d7","type":[0,0],"manufacturer_id":2,"description":"DYNA"},
-    "e00001":{"key":"7ab132c95f843da7116ed03b9cf20845","sequence":"0079","type":[0,0],"manufacturer_id":2,"description":"SUNS"},
-    "e00002":{"key":"bba24bbb61508fc78c5ad0e57ff66210","sequence":"0200","type":[0,0],"manufacturer_id":2,"description":"SUNG"}
+    "b60d1a": {
+        "key": "2d36bd8b4d4fb1e1a1b3099b394d3a9e",
+        "sequence": "2410",
+        "type": [
+            0,
+            0
+        ],
+        "manufacturer_id": 2,
+        "description": "IZY1",
+        "name": "IZY1"
+    },
+    "b60d1b": {
+        "key": "b794883327810507c2a5419eeeae54b4",
+        "sequence": "08d7",
+        "type": [
+            0,
+            0
+        ],
+        "manufacturer_id": 2,
+        "description": "IZY2",
+        "name": "IZY2"
+    },
+    "e8e150": {
+        "key": "77999e593262e207c8f992904ec4c4f2",
+        "sequence": "08d7",
+        "type": [
+            0,
+            0
+        ],
+        "manufacturer_id": 2,
+        "description": "DYNA",
+        "name": "DYNA"
+    },
+    "e00001": {
+        "key": "7ab132c95f843da7116ed03b9cf20845",
+        "sequence": "0079",
+        "type": [
+            0,
+            0
+        ],
+        "manufacturer_id": 2,
+        "description": "SUNS",
+        "name": "SUNS"
+    },
+    "e00002": {
+        "key": "bba24bbb61508fc78c5ad0e57ff66210",
+        "sequence": "0200",
+        "type": [
+            0,
+            0
+        ],
+        "manufacturer_id": 2,
+        "description": "SUNG",
+        "name": "SUNG"
+    }
 }

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -51,6 +51,7 @@ namespace IOHC {
             std::vector<uint8_t> type{};
             uint8_t manufacturer{};
             std::string description;
+            std::string name;
         };
 
         static iohcRemote1W* getInstance();

--- a/include/oled_display.h
+++ b/include/oled_display.h
@@ -18,6 +18,6 @@ extern Adafruit_SSD1306 display;
 
 bool initDisplay();
 void displayIpAddress(IPAddress ip);
-void display1WAction(const uint8_t *remote, const char *action, const char *dir);
+void display1WAction(const uint8_t *remote, const char *action, const char *dir, const char *name = nullptr);
 
 #endif // OLED_DISPLAY_H

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -166,7 +166,7 @@ namespace IOHC {
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 //                }
                 _radioInstance->send(packets2send);
-                display1WAction(r.node, remoteButtonToString(cmd), "TX");
+                display1WAction(r.node, remoteButtonToString(cmd), "TX", r.name.c_str());
                 break;
             }
 
@@ -210,7 +210,7 @@ namespace IOHC {
 //                }
                 _radioInstance->send(packets2send);
                 //printf("\n");
-                display1WAction(r.node, remoteButtonToString(cmd), "TX");
+                display1WAction(r.node, remoteButtonToString(cmd), "TX", r.name.c_str());
                 break;
             }
 
@@ -253,7 +253,7 @@ namespace IOHC {
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 //                }
                 _radioInstance->send(packets2send);
-                display1WAction(r.node, remoteButtonToString(cmd), "TX");
+                display1WAction(r.node, remoteButtonToString(cmd), "TX", r.name.c_str());
                 break;
             }
            default: {
@@ -481,7 +481,7 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
                 }
                 _radioInstance->send(packets2send);
-                display1WAction(r.node, remoteButtonToString(cmd), "TX");
+                display1WAction(r.node, remoteButtonToString(cmd), "TX", r.name.c_str());
                 break;
 //            }
         }
@@ -544,6 +544,7 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
             // _manufacturer = jobj["manufacturer_id"].as<uint8_t>();
             r.manufacturer = jobj["manufacturer_id"].as<uint8_t>();
             r.description = jobj["description"].as<std::string>();
+            r.name = jobj["name"].as<std::string>();
             remotes.push_back(r);
         }
 
@@ -579,6 +580,7 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
             // jobj["manufacturer_id"] = _manufacturer;
             jobj["manufacturer_id"] = r.manufacturer;
             jobj["description"] = r.description;
+            jobj["name"] = r.name;
         }
         serializeJson(doc, f);
         f.close();

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -59,7 +59,7 @@ void handleMqttConnect() {
     const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
     for (const auto &r : remotes) {
         std::string id = bytesToHexString(r.node, sizeof(r.node));
-        publishDiscovery(id, r.description);
+        publishDiscovery(id, r.name.empty() ? r.description : r.name);
         std::string t = "iown/" + id + "/set";
         mqttClient.subscribe(t.c_str(), 0);
     }

--- a/src/oled_display.cpp
+++ b/src/oled_display.cpp
@@ -40,7 +40,7 @@ void displayIpAddress(IPAddress ip) {
     display.display();
 }
 
-void display1WAction(const uint8_t *remote, const char *action, const char *dir) {
+void display1WAction(const uint8_t *remote, const char *action, const char *dir, const char *name) {
     std::string id = bytesToHexString(remote, 3);
     const auto *entry = IOHC::iohcRemoteMap::getInstance()->find(remote);
 
@@ -50,7 +50,9 @@ void display1WAction(const uint8_t *remote, const char *action, const char *dir)
     display.setCursor(0, 0);
     display.print(dir);
     display.println(":");
-    if (entry) {
+    if (name) {
+        display.println(name);
+    } else if (entry) {
         display.println(entry->name.c_str());
     } else {
         display.print("ID: ");


### PR DESCRIPTION
## Summary
- store a new `name` field in extras/1W.json
- load/save this name in Remote1W data structures
- send the name via MQTT discovery
- show the device name on the OLED display when sending commands

## Testing
- `pio run -t nobuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3e7c3b2c8326b559e60f0b0f5723