### PR TITLE
Move interact declarations to cpp

### DIFF
--- a/include/interact.h
+++ b/include/interact.h
@@ -28,8 +28,8 @@
 #include <algorithm>
 
 extern "C" {
-	#include "freertos/FreeRTOS.h"
-	#include "freertos/timers.h"
+        #include "freertos/FreeRTOS.h"
+        #include "freertos/timers.h"
 }
 
 #include <WiFi.h>
@@ -38,8 +38,8 @@ extern "C" {
 #include <Adafruit_SSD1306.h>
 #include <web_server_handler.h>
 //#if defined(MQTT)
-//  #include <AsyncMqttClient.h>
-//  #include <ArduinoJson.h>
+//#  include <AsyncMqttClient.h>
+//#  include <ArduinoJson.h>
 //#endif
 
 #if defined(MQTT)
@@ -58,127 +58,27 @@ namespace IOHC {
   #define MAXCMDS 50
 #endif
 
-inline TimerHandle_t wifiReconnectTimer;
-inline WiFiClient wifiClient;                 // Create an ESP32 WiFiClient class to connect to the MQTT server
+extern TimerHandle_t wifiReconnectTimer;
+extern WiFiClient wifiClient;                 // Create an ESP32 WiFiClient class to connect to the MQTT server
 extern Adafruit_SSD1306 display;
 
 enum class ConnState { Connecting, Connected, Disconnected };
-inline ConnState wifiStatus = ConnState::Connecting;
-inline ConnState mqttStatus = ConnState::Disconnected;
+extern ConnState wifiStatus;
+extern ConnState mqttStatus;
 
-inline void updateDisplayStatus() {
-  display.clearDisplay();
-  display.setCursor(0, 0);
-  display.print("WiFi: ");
-  switch (wifiStatus) {
-    case ConnState::Connected:
-      display.println("connected");
-      break;
-    case ConnState::Connecting:
-      display.println("connecting");
-      break;
-    default:
-      display.println("disconnected");
-      break;
-  }
-  display.setCursor(0, 10);
-  display.print("IP: ");
-  if (wifiStatus == ConnState::Connected) {
-    display.println(WiFi.localIP());
-  } else {
-    display.println("-");
-  }
-  display.setCursor(0, 20);
-  display.print("MQTT: ");
-  switch (mqttStatus) {
-    case ConnState::Connected:
-      display.println("connected");
-      break;
-    case ConnState::Connecting:
-      display.println("connecting");
-      break;
-    default:
-      display.println("disconnected");
-      break;
-  }
-  display.display();
-}
+void updateDisplayStatus();
+void tokenize(std::string const &str, const char delim, Tokens &out);
 
-  inline void tokenize(std::string const &str, const char delim, Tokens &out) {
-      // construct a stream from the string 
-      std::stringstream ss(str); 
+struct _cmdEntry {
+    char cmd[15];
+    char description[61];
+    void (*handler)(Tokens*);
+};
+extern _cmdEntry* _cmdHandler[MAXCMDS];
+extern uint8_t lastEntry;
 
-      std::string s; 
-      while (std::getline(ss, s, delim)) { 
-          out.push_back(s); 
-      } 
-  }
-  inline struct _cmdEntry {
-      char cmd[15];
-      char description[61];
-      void (*handler)(Tokens*);
-  } *_cmdHandler[MAXCMDS];
-
-  inline uint8_t lastEntry = 0;
-
-
-
-  inline void connectToWifi() {
-    Serial.println("Connecting to Wi-Fi via WiFiManager...");
-    wifiStatus = ConnState::Connecting;
-    updateDisplayStatus();
-    WiFiClass::mode(WIFI_STA);
-
-    // Keep radio tweaks
-    ESP_ERROR_CHECK(esp_wifi_set_promiscuous(true));
-    uint8_t primaryChan = 10;
-    wifi_second_chan_t secondChan = WIFI_SECOND_CHAN_NONE;
-    esp_wifi_set_channel(primaryChan, secondChan);
-    ESP_ERROR_CHECK(esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11B|WIFI_PROTOCOL_11G));
-    ESP_ERROR_CHECK(esp_wifi_set_promiscuous(false));
-    ESP_ERROR_CHECK(esp_wifi_scan_stop());
-
-    WiFiManager wm;
-    bool res = wm.autoConnect("iohc-setup");
-    if (!res) {
-      Serial.println("WiFiManager failed to connect");
-      wifiStatus = ConnState::Disconnected;
-    } else {
-      Serial.printf("Connected to WiFi. IP address: %s\n", WiFi.localIP().toString().c_str());
-      wifiStatus = ConnState::Connected;
-    }
-    updateDisplayStatus();
-  }
-
-inline void WiFiEvent(WiFiEvent_t event) {
-//    Serial.printf("[WiFi-event] event: %d\n", event);
-    switch(event) {
-    case SYSTEM_EVENT_STA_GOT_IP:
-        Serial.println("WiFi connected");
-        //byte mac[6];
-        Serial.printf(WiFi.macAddress().c_str());
-        Serial.printf(" IP address: %s ", WiFi.localIP().toString().c_str());
-        wifiStatus = ConnState::Connected;
-        updateDisplayStatus();
-        setupWebServer();
-        xTimerStop(wifiReconnectTimer, 0);
-        #if defined(MQTT)
-          connectToMqtt();
-        #endif
-        printf("\n");
-        break;
-    case SYSTEM_EVENT_STA_DISCONNECTED:
-        Serial.println("WiFi lost connection");
-        wifiStatus = ConnState::Disconnected;
-        updateDisplayStatus();
-        #if defined(MQTT)
-          xTimerStop(mqttReconnectTimer, 0); // ensure we don't reconnect to MQTT while reconnecting to Wi-Fi
-        #endif
-        xTimerStart(wifiReconnectTimer, 0);
-        break;
-    default: {}
-    }
-}
+void connectToWifi();
+void WiFiEvent(WiFiEvent_t event);
 
 #if defined(DEBUG)
   #ifndef DEBUG_PORT
@@ -186,120 +86,26 @@ inline void WiFiEvent(WiFiEvent_t event) {
   #endif
   #define LOG(func, ...) DEBUG_PORT.func(__VA_ARGS__)
 #else
-  #define LOG(func, ...) ;
+  #define LOG(func, ...)
 #endif
 
-// using Tokens = std::vector<std::string>;
 namespace Cmd {
 
-  inline char _rxbuffer[512];
-  inline uint8_t _len = 0;
-  inline uint8_t _avail = 0;
-
-
-    void createCommands();
-
-    inline bool verbosity = true;
-    inline bool pairMode = false;
-    inline bool scanMode = false;
-
+extern bool verbosity;
+extern bool pairMode;
+extern bool scanMode;
 
 #if defined(ESP32)
-      inline TimersUS::TickerUsESP32 kbd_tick;
+  extern TimersUS::TickerUsESP32 kbd_tick;
 #endif
 
-    inline TimerHandle_t consoleTimer;
+extern TimerHandle_t consoleTimer;
 
-  inline bool addHandler(char *cmd, char *description, void (*handler)(Tokens*)) {
-    for (uint8_t idx=0; idx<MAXCMDS; ++idx) {
-      if (_cmdHandler[idx] != nullptr) {} // Skip already allocated cmd handler
-      else {
-        void* alloc = malloc(sizeof(struct _cmdEntry));
-        if (!alloc)
-          return false;
-
-        _cmdHandler[idx] = static_cast<_cmdEntry *>(alloc);
-        memset(alloc, 0, sizeof(struct _cmdEntry));
-        strncpy(_cmdHandler[idx]->cmd, cmd, strlen(cmd)<sizeof(_cmdHandler[idx]->cmd)?strlen(cmd):sizeof(_cmdHandler[idx]->cmd) - 1);
-        strncpy(_cmdHandler[idx]->description, description, strlen(cmd)<sizeof(_cmdHandler[idx]->description)?strlen(description):sizeof(_cmdHandler[idx]->description) - 1);
-        _cmdHandler[idx]->handler = handler;
-
-        if (idx > lastEntry)
-          lastEntry = idx;
-        return true;
-      } 
-    }
-    return false;
-  }
-
-  inline char *cmdReceived(bool echo = false) {
-      _avail = Serial.available();
-      if (_avail)  {
-        _len += Serial.readBytes(&_rxbuffer[_len], _avail);
-  //      receivingSerial = true;
-        if (echo) {
-          _rxbuffer[_len] = '\0';
-          Serial.printf("%s", &_rxbuffer[_len - _avail]);
-        }
-      }
-      if (_rxbuffer[_len-1] == 0x0a) {
-          _rxbuffer[_len-2] = '\0';
-          _len = 0;
-  //        receivingSerial = false;
-          return _rxbuffer;
-      }
-      return nullptr;
-  }
-
-  inline void cmdFuncHandler() {
-    constexpr char delim = ' ';
-    Tokens segments; 
-
-    char* _cmd = cmdReceived(true);
-    if (!_cmd) return;
-    if (!strlen(_cmd)) return;
-
-    tokenize(_cmd, delim, segments);
-    if (strcmp((char *)"help", segments[0].c_str()) == 0) {
-      Serial.printf("\nRegistered commands:\n");
-      for (uint8_t idx=0; idx<=lastEntry; ++idx) {
-        if (_cmdHandler[idx] == nullptr) continue;
-        Serial.printf("- %s\t%s\n", _cmdHandler[idx]->cmd, _cmdHandler[idx]->description);
-      }
-      Serial.printf("- %s\t%s\n\n", (char*)"help", (char*)"This command");
-      Serial.printf("\n");
-      return;
-    }
-    for (uint8_t idx=0; idx<=lastEntry; ++idx) {
-      if (_cmdHandler[idx] == nullptr) continue;
-      if (strcmp(_cmdHandler[idx]->cmd, segments[0].c_str()) == 0) {
-        _cmdHandler[idx]->handler(&segments);
-        return;
-      }
-    }
-    Serial.printf("*> Unknown <*\n");
-  }
-  
-  inline void init() {
-    
-    #if defined(MQTT)
-      mqttClient.setClientId("iown");
-      mqttClient.setCredentials(MQTT_USER, MQTT_PASSWD);
-      mqttClient.setServer(MQTT_SERVER, 1883);
-      mqttClient.onConnect(onMqttConnect);
-      mqttClient.onDisconnect(onMqttDisconnect);
-      mqttClient.onMessage(onMqttMessage);
-      mqttReconnectTimer = xTimerCreate("mqttTimer", pdMS_TO_TICKS(5000), pdFALSE, nullptr, reinterpret_cast<TimerCallbackFunction_t>(connectToMqtt));
-    #endif
-
-    wifiReconnectTimer = xTimerCreate("wifiTimer", pdMS_TO_TICKS(5000), pdFALSE, nullptr, reinterpret_cast<TimerCallbackFunction_t>(connectToWifi));
-
-    WiFi.onEvent(WiFiEvent);
-    connectToWifi();
-
-//    consoleTimer = xTimerCreate("consoleTimer", pdMS_TO_TICKS(500), pdFALSE, nullptr, reinterpret_cast<TimerCallbackFunction_t>(cmdFuncHandler));
-    kbd_tick.attach_ms(500, cmdFuncHandler);
-
-  }  
+bool addHandler(char *cmd, char *description, void (*handler)(Tokens*));
+char *cmdReceived(bool echo = false);
+void cmdFuncHandler();
+void createCommands();
+void init();
 }
+
 #endif

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -21,7 +21,127 @@
 #include <iohcCryptoHelpers.h>
 #include <mqtt_handler.h>
 
+TimerHandle_t wifiReconnectTimer;
+WiFiClient wifiClient;
+ConnState wifiStatus = ConnState::Connecting;
+ConnState mqttStatus = ConnState::Disconnected;
+
+_cmdEntry* _cmdHandler[MAXCMDS];
+uint8_t lastEntry = 0;
+
+void updateDisplayStatus() {
+  display.clearDisplay();
+  display.setCursor(0, 0);
+  display.print("WiFi: ");
+  switch (wifiStatus) {
+    case ConnState::Connected:
+      display.println("connected");
+      break;
+    case ConnState::Connecting:
+      display.println("connecting");
+      break;
+    default:
+      display.println("disconnected");
+      break;
+  }
+  display.setCursor(0, 10);
+  display.print("IP: ");
+  if (wifiStatus == ConnState::Connected) {
+    display.println(WiFi.localIP());
+  } else {
+    display.println("-");
+  }
+  display.setCursor(0, 20);
+  display.print("MQTT: ");
+  switch (mqttStatus) {
+    case ConnState::Connected:
+      display.println("connected");
+      break;
+    case ConnState::Connecting:
+      display.println("connecting");
+      break;
+    default:
+      display.println("disconnected");
+      break;
+  }
+  display.display();
+}
+
+void tokenize(std::string const &str, const char delim, Tokens &out) {
+  std::stringstream ss(str);
+  std::string s;
+  while (std::getline(ss, s, delim)) {
+    out.push_back(s);
+  }
+}
+
+void connectToWifi() {
+  Serial.println("Connecting to Wi-Fi via WiFiManager...");
+  wifiStatus = ConnState::Connecting;
+  updateDisplayStatus();
+  WiFiClass::mode(WIFI_STA);
+
+  ESP_ERROR_CHECK(esp_wifi_set_promiscuous(true));
+  uint8_t primaryChan = 10;
+  wifi_second_chan_t secondChan = WIFI_SECOND_CHAN_NONE;
+  esp_wifi_set_channel(primaryChan, secondChan);
+  ESP_ERROR_CHECK(esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11B|WIFI_PROTOCOL_11G));
+  ESP_ERROR_CHECK(esp_wifi_set_promiscuous(false));
+  ESP_ERROR_CHECK(esp_wifi_scan_stop());
+
+  WiFiManager wm;
+  bool res = wm.autoConnect("iohc-setup");
+  if (!res) {
+    Serial.println("WiFiManager failed to connect");
+    wifiStatus = ConnState::Disconnected;
+  } else {
+    Serial.printf("Connected to WiFi. IP address: %s\n", WiFi.localIP().toString().c_str());
+    wifiStatus = ConnState::Connected;
+  }
+  updateDisplayStatus();
+}
+
+void WiFiEvent(WiFiEvent_t event) {
+    switch(event) {
+    case SYSTEM_EVENT_STA_GOT_IP:
+        Serial.println("WiFi connected");
+        Serial.printf(WiFi.macAddress().c_str());
+        Serial.printf(" IP address: %s ", WiFi.localIP().toString().c_str());
+        wifiStatus = ConnState::Connected;
+        updateDisplayStatus();
+        setupWebServer();
+        xTimerStop(wifiReconnectTimer, 0);
+#if defined(MQTT)
+        connectToMqtt();
+#endif
+        printf("\n");
+        break;
+    case SYSTEM_EVENT_STA_DISCONNECTED:
+        Serial.println("WiFi lost connection");
+        wifiStatus = ConnState::Disconnected;
+        updateDisplayStatus();
+#if defined(MQTT)
+        xTimerStop(mqttReconnectTimer, 0);
+#endif
+        xTimerStart(wifiReconnectTimer, 0);
+        break;
+    default:
+        break;
+    }
+}
+
 namespace Cmd {
+bool verbosity = true;
+bool pairMode = false;
+bool scanMode = false;
+#if defined(ESP32)
+TimersUS::TickerUsESP32 kbd_tick;
+#endif
+TimerHandle_t consoleTimer;
+
+static char _rxbuffer[512];
+static uint8_t _len = 0;
+static uint8_t _avail = 0;
 /**
  * The function `createCommands()` initializes and adds various command handlers for controlling
  * different devices and functionalities.
@@ -195,5 +315,105 @@ void createCommands() {
         //Register it like any other command
         console.registerCommand(setTemp);
     */
+}
+
+bool addHandler(char *cmd, char *description, void (*handler)(Tokens*)) {
+  for (uint8_t idx = 0; idx < MAXCMDS; ++idx) {
+    if (_cmdHandler[idx] != nullptr) {
+    } else {
+      void *alloc = malloc(sizeof(struct _cmdEntry));
+      if (!alloc)
+        return false;
+
+      _cmdHandler[idx] = static_cast<_cmdEntry *>(alloc);
+      memset(alloc, 0, sizeof(struct _cmdEntry));
+      strncpy(_cmdHandler[idx]->cmd, cmd,
+              strlen(cmd) < sizeof(_cmdHandler[idx]->cmd) ? strlen(cmd)
+                                                          : sizeof(_cmdHandler[idx]->cmd) - 1);
+      strncpy(_cmdHandler[idx]->description, description,
+              strlen(cmd) < sizeof(_cmdHandler[idx]->description)
+                  ? strlen(description)
+                  : sizeof(_cmdHandler[idx]->description) - 1);
+      _cmdHandler[idx]->handler = handler;
+
+      if (idx > lastEntry)
+        lastEntry = idx;
+      return true;
+    }
+  }
+  return false;
+}
+
+char *cmdReceived(bool echo) {
+  _avail = Serial.available();
+  if (_avail) {
+    _len += Serial.readBytes(&_rxbuffer[_len], _avail);
+    if (echo) {
+      _rxbuffer[_len] = '\0';
+      Serial.printf("%s", &_rxbuffer[_len - _avail]);
+    }
+  }
+  if (_rxbuffer[_len - 1] == 0x0a) {
+    _rxbuffer[_len - 2] = '\0';
+    _len = 0;
+    return _rxbuffer;
+  }
+  return nullptr;
+}
+
+void cmdFuncHandler() {
+  constexpr char delim = ' ';
+  Tokens segments;
+
+  char *cmd = cmdReceived(true);
+  if (!cmd)
+    return;
+  if (!strlen(cmd))
+    return;
+
+  tokenize(cmd, delim, segments);
+  if (strcmp((char *)"help", segments[0].c_str()) == 0) {
+    Serial.printf("\nRegistered commands:\n");
+    for (uint8_t idx = 0; idx <= lastEntry; ++idx) {
+      if (_cmdHandler[idx] == nullptr)
+        continue;
+      Serial.printf("- %s\t%s\n", _cmdHandler[idx]->cmd, _cmdHandler[idx]->description);
+    }
+    Serial.printf("- %s\t%s\n\n", (char *)"help", (char *)"This command");
+    Serial.printf("\n");
+    return;
+  }
+  for (uint8_t idx = 0; idx <= lastEntry; ++idx) {
+    if (_cmdHandler[idx] == nullptr)
+      continue;
+    if (strcmp(_cmdHandler[idx]->cmd, segments[0].c_str()) == 0) {
+      _cmdHandler[idx]->handler(&segments);
+      return;
+    }
+  }
+  Serial.printf("*> Unknown <*\n");
+}
+
+void init() {
+#if defined(MQTT)
+  mqttClient.setClientId("iown");
+  mqttClient.setCredentials(MQTT_USER, MQTT_PASSWD);
+  mqttClient.setServer(MQTT_SERVER, 1883);
+  mqttClient.onConnect(onMqttConnect);
+  mqttClient.onDisconnect(onMqttDisconnect);
+  mqttClient.onMessage(onMqttMessage);
+  mqttReconnectTimer = xTimerCreate("mqttTimer", pdMS_TO_TICKS(5000), pdFALSE,
+                                   nullptr,
+                                   reinterpret_cast<TimerCallbackFunction_t>(connectToMqtt));
+#endif
+
+  wifiReconnectTimer = xTimerCreate("wifiTimer", pdMS_TO_TICKS(5000), pdFALSE,
+                                    nullptr,
+                                    reinterpret_cast<TimerCallbackFunction_t>(connectToWifi));
+
+  WiFi.onEvent(WiFiEvent);
+  connectToWifi();
+
+  kbd_tick.attach_ms(500, cmdFuncHandler);
 }
 }


### PR DESCRIPTION
## Summary
- convert interact.h to a header with only extern vars and function prototypes
- implement wifi helpers and command handlers in interact.cpp
- define globals in the cpp file

## Testing
- `pio run` *(fails: `pio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a513313208326b60995871ac4619f