### PR TITLE
Refactor display status handling

### DIFF
--- a/include/interact.h
+++ b/include/interact.h
@@ -65,8 +65,6 @@ extern Adafruit_SSD1306 display;
 enum class ConnState { Connecting, Connected, Disconnected };
 extern ConnState wifiStatus;
 extern ConnState mqttStatus;
-
-void updateDisplayStatus();
 void tokenize(std::string const &str, const char delim, Tokens &out);
 
 struct _cmdEntry {

--- a/include/oled_display.h
+++ b/include/oled_display.h
@@ -19,5 +19,6 @@ extern Adafruit_SSD1306 display;
 bool initDisplay();
 void displayIpAddress(IPAddress ip);
 void display1WAction(const uint8_t *remote, const char *action, const char *dir, const char *name = nullptr);
+void updateDisplayStatus();
 
 #endif // OLED_DISPLAY_H

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -18,6 +18,7 @@
 #include <iohcCozyDevice2W.h>
 #include <iohcOtherDevice2W.h>
 #include <interact.h>
+#include <oled_display.h>
 #include <iohcCryptoHelpers.h>
 #include <mqtt_handler.h>
 
@@ -29,43 +30,6 @@ ConnState mqttStatus = ConnState::Disconnected;
 _cmdEntry* _cmdHandler[MAXCMDS];
 uint8_t lastEntry = 0;
 
-void updateDisplayStatus() {
-  display.clearDisplay();
-  display.setCursor(0, 0);
-  display.print("WiFi: ");
-  switch (wifiStatus) {
-    case ConnState::Connected:
-      display.println("connected");
-      break;
-    case ConnState::Connecting:
-      display.println("connecting");
-      break;
-    default:
-      display.println("disconnected");
-      break;
-  }
-  display.setCursor(0, 10);
-  display.print("IP: ");
-  if (wifiStatus == ConnState::Connected) {
-    display.println(WiFi.localIP());
-  } else {
-    display.println("-");
-  }
-  display.setCursor(0, 20);
-  display.print("MQTT: ");
-  switch (mqttStatus) {
-    case ConnState::Connected:
-      display.println("connected");
-      break;
-    case ConnState::Connecting:
-      display.println("connecting");
-      break;
-    default:
-      display.println("disconnected");
-      break;
-  }
-  display.display();
-}
 
 void tokenize(std::string const &str, const char delim, Tokens &out) {
   std::stringstream ss(str);

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -5,6 +5,7 @@
 #include <AsyncMqttClient.h>
 #include <ArduinoJson.h>
 #include <interact.h>
+#include <oled_display.h>
 
 AsyncMqttClient mqttClient;
 TimerHandle_t mqttReconnectTimer;

--- a/src/oled_display.cpp
+++ b/src/oled_display.cpp
@@ -17,6 +17,8 @@
 #include <oled_display.h>
 #include <iohcCryptoHelpers.h>
 #include <iohcRemoteMap.h>
+#include <interact.h>
+#include <WiFi.h>
 
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RST);
 
@@ -60,5 +62,43 @@ void display1WAction(const uint8_t *remote, const char *action, const char *dir,
     }
     display.print("Action: ");
     display.println(action);
+    display.display();
+}
+
+void updateDisplayStatus() {
+    display.clearDisplay();
+    display.setCursor(0, 0);
+    display.print("WiFi: ");
+    switch (wifiStatus) {
+        case ConnState::Connected:
+            display.println("connected");
+            break;
+        case ConnState::Connecting:
+            display.println("connecting");
+            break;
+        default:
+            display.println("disconnected");
+            break;
+    }
+    display.setCursor(0, 10);
+    display.print("IP: ");
+    if (wifiStatus == ConnState::Connected) {
+        display.println(WiFi.localIP());
+    } else {
+        display.println("-");
+    }
+    display.setCursor(0, 20);
+    display.print("MQTT: ");
+    switch (mqttStatus) {
+        case ConnState::Connected:
+            display.println("connected");
+            break;
+        case ConnState::Connecting:
+            display.println("connecting");
+            break;
+        default:
+            display.println("disconnected");
+            break;
+    }
     display.display();
 }


### PR DESCRIPTION
## Summary
- move `updateDisplayStatus` implementation out of interact
- centralize display code in `oled_display`
- include `oled_display.h` wherever the display update is used

## Testing
- `trunk check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5095af208326a1c4588d776dc9a7