### PR TITLE
Move MQTT initialization to handler

### DIFF
--- a/include/interact.h
+++ b/include/interact.h
@@ -282,13 +282,7 @@ namespace Cmd {
   inline void init() {
     
     #if defined(MQTT)
-      mqttClient.setClientId("iown");
-      mqttClient.setCredentials(MQTT_USER, MQTT_PASSWD);
-      mqttClient.setServer(MQTT_SERVER, 1883);
-      mqttClient.onConnect(onMqttConnect);
-      mqttClient.onDisconnect(onMqttDisconnect);
-      mqttClient.onMessage(onMqttMessage);
-      mqttReconnectTimer = xTimerCreate("mqttTimer", pdMS_TO_TICKS(5000), pdFALSE, nullptr, reinterpret_cast<TimerCallbackFunction_t>(connectToMqtt));
+      initMqtt();
     #endif
 
     wifiReconnectTimer = xTimerCreate("wifiTimer", pdMS_TO_TICKS(5000), pdFALSE, nullptr, reinterpret_cast<TimerCallbackFunction_t>(connectToWifi));

--- a/include/mqtt_handler.h
+++ b/include/mqtt_handler.h
@@ -13,6 +13,7 @@ extern TimerHandle_t mqttReconnectTimer;
 extern TimerHandle_t heartbeatTimer;
 extern const char AVAILABILITY_TOPIC[];
 
+void initMqtt();
 void connectToMqtt();
 void onMqttConnect(bool sessionPresent);
 void onMqttDisconnect(AsyncMqttClientDisconnectReason reason);

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -11,6 +11,18 @@ TimerHandle_t mqttReconnectTimer;
 TimerHandle_t heartbeatTimer;
 const char AVAILABILITY_TOPIC[] = "iown/status";
 
+void initMqtt() {
+    mqttClient.setClientId("iown");
+    mqttClient.setCredentials(MQTT_USER, MQTT_PASSWD);
+    mqttClient.setServer(MQTT_SERVER, 1883);
+    mqttClient.onConnect(onMqttConnect);
+    mqttClient.onDisconnect(onMqttDisconnect);
+    mqttClient.onMessage(onMqttMessage);
+    mqttReconnectTimer = xTimerCreate("mqttTimer", pdMS_TO_TICKS(5000), pdFALSE,
+                                      nullptr,
+                                      reinterpret_cast<TimerCallbackFunction_t>(connectToMqtt));
+}
+
 void publishDiscovery(const std::string &id, const std::string &name) {
     JsonDocument doc;
     doc["name"] = name;


### PR DESCRIPTION
## Summary
- centralize MQTT client setup in mqtt_handler
- call new initMqtt routine from Cmd::init

## Testing
- `pio` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a914b81ac832696ebfce29a6953c6