### PR TITLE
Initialize network services from setup

### DIFF
--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -55,7 +55,6 @@ static uint8_t _avail = 0;
  * different devices and functionalities.
  */
 void createCommands() {
-    Cmd::init(); // Initialize Serial commands reception and handlers
     // Atlantic 2W
     Cmd::addHandler((char *) "powerOn", (char *) "Permit to retrieve paired devices", [](Tokens *cmd)-> void {
         IOHC::iohcCozyDevice2W::getInstance()->cmd(IOHC::DeviceButton::powerOn, nullptr);


### PR DESCRIPTION
## Summary
- include wifi helper in main
- start WiFi, MQTT and the web server from `setup()`
- remove `Cmd::init()` call from `createCommands`

## Testing
- `pio run` *(fails: `pio` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9c83e49083268647b307930ed839