### PR TITLE
Move WiFi timer setup into helper

### DIFF
--- a/include/wifi_helper.h
+++ b/include/wifi_helper.h
@@ -26,6 +26,7 @@ extern TimerHandle_t wifiReconnectTimer;
 extern WiFiClient wifiClient;
 extern ConnState wifiStatus;
 
+void initWifi();
 void connectToWifi();
 void WiFiEvent(WiFiEvent_t event);
 

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -306,12 +306,7 @@ void init() {
 initMqtt();
 #endif
 
-  wifiReconnectTimer = xTimerCreate("wifiTimer", pdMS_TO_TICKS(5000), pdFALSE,
-                                    nullptr,
-                                    reinterpret_cast<TimerCallbackFunction_t>(connectToWifi));
-
-  WiFi.onEvent(WiFiEvent);
-  connectToWifi();
+  initWifi();
 
   kbd_tick.attach_ms(500, cmdFuncHandler);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,12 +93,8 @@ void setup() {
     Serial.println("LittleFS mounted successfully");
 #endif
 
-    // Initialize WiFi, MQTT and WebServer
-    wifiReconnectTimer = xTimerCreate("wifiTimer", pdMS_TO_TICKS(5000), pdFALSE,
-                                      nullptr,
-                                      reinterpret_cast<TimerCallbackFunction_t>(connectToWifi));
-    WiFi.onEvent(WiFiEvent);
-    connectToWifi();
+    // Initialize network services
+    initWifi();
 #if defined(MQTT)
     initMqtt();
 #endif

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -22,6 +22,14 @@ TimerHandle_t wifiReconnectTimer;
 WiFiClient wifiClient;
 ConnState wifiStatus = ConnState::Connecting;
 
+void initWifi() {
+  wifiReconnectTimer = xTimerCreate("wifiTimer", pdMS_TO_TICKS(5000), pdFALSE,
+                                    nullptr,
+                                    reinterpret_cast<TimerCallbackFunction_t>(connectToWifi));
+  WiFi.onEvent(WiFiEvent);
+  connectToWifi();
+}
+
 void connectToWifi() {
   Serial.println("Connecting to Wi-Fi via WiFiManager...");
   wifiStatus = ConnState::Connecting;


### PR DESCRIPTION
## Summary
- initialize wifi reconnect timer inside `wifi_helper`
- call new `initWifi` routine from setup and command init

## Testing
- `pio run` *(fails: platform packages blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686aa96946b083269db256295e3bce02