### PR TITLE
Make OLED display optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Example payload for `B60D1A`:
 
 Configure your MQTT broker settings in `include/user_config.h` (`MQTT_SERVER`, `MQTT_USER`, `MQTT_PASSWD`). After boot and connection, Home Assistant should automatically discover the covers.
 
+If you don't have an OLED display connected, comment out the `DISPLAY` definition in `include/user_config.h` to disable all display related code.
+
 Once discovery is complete you can control a blind by publishing `OPEN`, `CLOSE`
 or `STOP` to `iown/<id>/set`. The firmware listens on these topics and issues the
 corresponding command to the device.

--- a/include/interact.h
+++ b/include/interact.h
@@ -32,7 +32,9 @@ extern "C" {
         #include "freertos/timers.h"
 }
 
+#if defined(DISPLAY)
 #include <Adafruit_SSD1306.h>
+#endif
 #include <web_server_handler.h>
 //#if defined(MQTT)
 //#  include <AsyncMqttClient.h>
@@ -55,7 +57,9 @@ namespace IOHC {
   #define MAXCMDS 50
 #endif
 
+#if defined(DISPLAY)
 extern Adafruit_SSD1306 display;
+#endif
 
 enum class ConnState { Connecting, Connected, Disconnected };
 extern ConnState mqttStatus;

--- a/include/oled_display.h
+++ b/include/oled_display.h
@@ -2,6 +2,9 @@
 #define OLED_DISPLAY_H
 
 #include <board-config.h>
+#include <user_config.h>
+
+#if defined(DISPLAY)
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 #include <Wire.h>
@@ -21,5 +24,11 @@ bool initDisplay();
 void displayIpAddress(IPAddress ip);
 void display1WAction(const uint8_t *remote, const char *action, const char *dir, const char *name = nullptr);
 void updateDisplayStatus();
+#else
+inline bool initDisplay() { return true; }
+inline void displayIpAddress(IPAddress) {}
+inline void display1WAction(const uint8_t *, const char *, const char *, const char * = nullptr) {}
+inline void updateDisplayStatus() {}
+#endif
 
 #endif // OLED_DISPLAY_H

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -33,6 +33,9 @@ inline const char *mqtt_server = "192.168.1.40";
 inline const char *mqtt_user = "user";
 inline const char *mqtt_password = "passwd";
 
+// Comment out the next line if no display is connected
+#define DISPLAY
+
 #define HTTP_LISTEN_PORT    80
 #define HTTP_USERNAME       "admin"
 #define HTTP_PASSWORD       "admin"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,10 @@
 //#include <WiFi.h> // Assuming WiFi is used and initialized elsewhere or will be here.
 
 
+#include <user_config.h>
+#if defined(DISPLAY)
 #include <oled_display.h>
+#endif
 
 
 extern "C" {
@@ -77,7 +80,9 @@ using namespace IOHC;
 void setup() {
     Serial.begin(115200);       //Start serial connection for debug and manual input
 
-    initDisplay(); // Init Olded display
+#if defined(DISPLAY)
+    initDisplay(); // Init OLED display
+#endif
 
     pinMode(RX_LED, OUTPUT); // Blink this LED
     digitalWrite(RX_LED, 1);

--- a/src/oled_display.cpp
+++ b/src/oled_display.cpp
@@ -14,6 +14,8 @@
    limitations under the License.
  */
 
+#include <user_config.h>
+#if defined(DISPLAY)
 #include <oled_display.h>
 #include <iohcCryptoHelpers.h>
 #include <iohcRemoteMap.h>
@@ -108,3 +110,5 @@ void updateDisplayStatus() {
     }
     display.display();
 }
+
+#endif


### PR DESCRIPTION
## Summary
- add `DISPLAY` macro to enable or disable the OLED display
- guard display code with `#if defined(DISPLAY)`
- add stub functions when display is disabled
- document the option in the README

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870215d28548326aa5d86802bb412ef