### PR TITLE
Make web server optional via user_config

### DIFF
--- a/include/interact.h
+++ b/include/interact.h
@@ -35,7 +35,10 @@ extern "C" {
 #if defined(DISPLAY)
 #include <Adafruit_SSD1306.h>
 #endif
+
+#if defined(WEBSERVER)
 #include <web_server_handler.h>
+#endif
 //#if defined(MQTT)
 //#  include <AsyncMqttClient.h>
 //#  include <ArduinoJson.h>

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -36,6 +36,9 @@ inline const char *mqtt_password = "passwd";
 // Comment out the next line if no display is connected
 #define DISPLAY
 
+// Comment out the next line to disable the built-in web server
+#define WEBSERVER
+
 #define HTTP_LISTEN_PORT    80
 #define HTTP_USERNAME       "admin"
 #define HTTP_PASSWORD       "admin"

--- a/include/web_server_handler.h
+++ b/include/web_server_handler.h
@@ -4,9 +4,14 @@
 #include <Arduino.h>
 
 // Forward declaration if ESPAsyncWebServer is used
-class ESPAsyncWebServer; 
+class ESPAsyncWebServer;
 
+#if defined(WEBSERVER)
 void setupWebServer();
 void loopWebServer(); // If any loop processing is needed for the web server
+#else
+inline void setupWebServer() {}
+inline void loopWebServer() {}
+#endif
 
 #endif // WEB_SERVER_HANDLER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,9 @@
 #include <mqtt_handler.h>
 #include <wifi_helper.h>
 
+#if defined(WEBSERVER)
 #include <web_server_handler.h>
+#endif
 #include "LittleFS.h"
 //#include <WiFi.h> // Assuming WiFi is used and initialized elsewhere or will be here.
 
@@ -103,7 +105,9 @@ void setup() {
 #if defined(MQTT)
     initMqtt();
 #endif
+#if defined(WEBSERVER)
     setupWebServer();
+#endif
     Cmd::kbd_tick.attach_ms(500, Cmd::cmdFuncHandler);
 
     radioInstance = IOHC::iohcRadio::getInstance();

--- a/src/web_server_handler.cpp
+++ b/src/web_server_handler.cpp
@@ -1,4 +1,6 @@
 #include <web_server_handler.h>
+
+#if defined(WEBSERVER)
 #include "ESPAsyncWebServer.h" // Or WebServer.h if that's preferred for memory
 #include "ArduinoJson.h"       // For creating JSON responses
 #include <LittleFS.h>
@@ -122,3 +124,10 @@ void loopWebServer() {
     // For ESPAsyncWebServer, most work is done asynchronously.
     // For the basic WebServer.h, you would need server.handleClient() here.
 }
+
+#else
+
+void setupWebServer() {}
+void loopWebServer() {}
+
+#endif


### PR DESCRIPTION
## Summary
- allow disabling the web server at compile time
- wrap web-server includes and calls behind `WEBSERVER` macro
- provide empty stubs when the web server is disabled

## Testing
- `pip install platformio`
- `pio check` *(fails: HTTPClientError due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_6872a5abdaf88326a8ee093976dff4ca