### PR TITLE
Fix MQTT connection resilience

### DIFF
--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -6,6 +6,8 @@
 #include <ArduinoJson.h>
 #include <interact.h>
 #include <oled_display.h>
+#include <cstring>
+#include <WiFi.h>
 
 AsyncMqttClient mqttClient;
 TimerHandle_t mqttReconnectTimer;
@@ -84,7 +86,16 @@ void handleMqttConnect() {
 }
 
 void connectToMqtt() {
-    Serial.println("Connecting to MQTT...");
+    if (WiFi.status() != WL_CONNECTED) {
+        Serial.println("WiFi not connected, delaying MQTT connection");
+        xTimerStart(mqttReconnectTimer, pdMS_TO_TICKS(5000));
+        return;
+    }
+    if (strlen(MQTT_SERVER) == 0) {
+        Serial.println("MQTT server not configured");
+        return;
+    }
+    Serial.printf("Connecting to MQTT at %s...\n", MQTT_SERVER);
     mqttStatus = ConnState::Connecting;
     updateDisplayStatus();
     mqttClient.connect();
@@ -127,8 +138,9 @@ void onMqttConnect(bool sessionPresent) {
     handleMqttConnect();
 }
 
-void onMqttDisconnect(AsyncMqttClientDisconnectReason) {
-    Serial.println("Disconnected from MQTT.");
+void onMqttDisconnect(AsyncMqttClientDisconnectReason reason) {
+    Serial.print("Disconnected from MQTT. Reason: ");
+    Serial.println(static_cast<uint8_t>(reason));
     mqttStatus = ConnState::Disconnected;
     updateDisplayStatus();
     xTimerStart(mqttReconnectTimer, 0);

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -56,6 +56,10 @@ void connectToWifi() {
         Serial.printf("Connected to WiFi. IP address: %s\n", WiFi.localIP().toString().c_str());
         wifiStatus = ConnState::Connected;
         updateDisplayStatus();
+#if defined(MQTT)
+        // Kick off MQTT connection when WiFi becomes available
+        xTimerStart(mqttReconnectTimer, 0);
+#endif
     }
 }
 


### PR DESCRIPTION
## Summary
- restart MQTT connection when WiFi reconnects
- delay MQTT connection until WiFi is ready
- print disconnect reason for debugging

## Testing
- `trunk check` *(fails: command not found)*
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c33513dc8326bce8f62cd96f7f60