### PR TITLE
Add compile-time switch for MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This feature is under development, and functionality will be expanded in the fut
 
 ## Home Assistant Discovery
 
-When MQTT is enabled (`#define MQTT` in `include/user_config.h`) the firmware publishes Home Assistant discovery messages for every blind defined in `extras/1W.json` as soon as the MQTT connection is established.
+When MQTT is enabled (`#define MQTT` in `include/user_config.h`) the firmware publishes Home Assistant discovery messages for every blind defined in `extras/1W.json` as soon as the MQTT connection is established. Comment out the `MQTT` definition if you do not wish to compile the firmware with MQTT support.
 
 Each blind configuration is sent to the topic `homeassistant/cover/<id>/config` where `<id>` is the hexadecimal address from `1W.json`.
 

--- a/include/mqtt_handler.h
+++ b/include/mqtt_handler.h
@@ -1,9 +1,11 @@
 #ifndef MQTT_HANDLER_H
 #define MQTT_HANDLER_H
 
-//#include <interact.h>
+/* MQTT support can be enabled or disabled via the `MQTT` define in
+ * `user_config.h`.  When disabled, this header becomes effectively empty so
+ * other source files can include it unconditionally. */
 
-//#if defined(MQTT)
+#if defined(MQTT)
 
 #include <AsyncMqttClient.h>
 #include <ArduinoJson.h>
@@ -25,7 +27,7 @@ void handleMqttConnect();
 void publishHeartbeat(TimerHandle_t timer);
 void mqttFuncHandler(const char *cmd);
 
-//#endif // MQTT
+#endif // MQTT
 
 #endif // MQTT_HANDLER_H
 

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -21,7 +21,9 @@
 #include <wifi_helper.h>
 #include <oled_display.h>
 #include <iohcCryptoHelpers.h>
+#if defined(MQTT)
 #include <mqtt_handler.h>
+#endif
 
 ConnState mqttStatus = ConnState::Disconnected;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,9 @@
 #include <iohcOtherDevice2W.h>
 #include <iohcRemoteMap.h>
 #include <interact.h>
+#if defined(MQTT)
 #include <mqtt_handler.h>
+#endif
 #include <wifi_helper.h>
 
 #if defined(WEBSERVER)

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -1,5 +1,7 @@
 #include <mqtt_handler.h>
 
+#if defined(MQTT)
+
 #include <iohcRemote1W.h>
 #include <iohcCryptoHelpers.h>
 #include <AsyncMqttClient.h>
@@ -219,3 +221,4 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
         snprintf(message, sizeof(message), "MQTT %s %s", topic, data);
     mqttFuncHandler(message);
 }
+#endif // MQTT

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -16,7 +16,9 @@
 
 #include <wifi_helper.h>
 #include <oled_display.h>
+#if defined(MQTT)
 #include <mqtt_handler.h>
+#endif
 #include <WiFiManager.h>
 
 TimerHandle_t wifiReconnectTimer;


### PR DESCRIPTION
## Summary
- allow building without MQTT by wrapping all MQTT code in `#if defined(MQTT)`
- clarify README on how to disable MQTT

## Testing
- `pio run -e HeltecLoraV2ESP32` *(fails: PlatformIO can't download espressif32 platform)*
- `pio check` *(fails: PlatformIO can't download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6872b416a338832686dcaca8643d8dea