### PR TITLE
Introduce RadioState enumeration

### DIFF
--- a/include/iohcRadio.h
+++ b/include/iohcRadio.h
@@ -18,6 +18,7 @@
 #define IOHC_RADIO_H
 
 #include <Delegate.h>
+#include <cstdint>
 
 #include <board-config.h>
 #include <iohcCryptoHelpers.h>
@@ -52,9 +53,16 @@ namespace IOHC {
             virtual ~iohcRadio() = default;
             void start(uint8_t num_freqs, uint32_t *scan_freqs, uint32_t scanTimeUs, IohcPacketDelegate rxCallback, IohcPacketDelegate txCallback);
             void send(std::vector<iohcPacket*>&iohcTx);
-            volatile static bool _g_preamble;
-            volatile static bool _g_payload;
-            volatile static bool f_lock;
+            enum class RadioState : uint8_t {
+                IDLE,        ///< Default state: nothing happening
+                RX,          ///< Receiving mode
+                TX,          ///< Transmitting mode
+                PREAMBLE,    ///< Preamble detected
+                PAYLOAD,     ///< Payload available
+                LOCKED,      ///< Frequency locked
+                ERROR        ///< Error or unknown state
+            };
+            volatile static RadioState radioState;
             static void tickerCounter(iohcRadio *radio);
 
         private:
@@ -67,7 +75,6 @@ namespace IOHC {
             volatile static unsigned long _g_payload_millis;
             
             volatile static bool send_lock;
-            volatile static bool txMode;
 
             volatile uint32_t tickCounter = 0;
             volatile uint32_t preCounter = 0;


### PR DESCRIPTION
## Summary
- add RadioState enum inside `iohcRadio`
- remove legacy preamble, payload and TX mode flags
- update ISR and state machine to rely on `radioState`

## Testing
- `pip install platformio`
- `pio run -e HeltecLoraV2ESP32` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68795793970083268b654720165bc20b