### PR TITLE
Improve OLED position feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ When MQTT is enabled (`#define MQTT` in `include/user_config.h`) the firmware pu
 
 Each blind configuration is sent to the topic `homeassistant/cover/<id>/config` where `<id>` is the hexadecimal address from `1W.json`.
 
-The `1W.json` file now accepts an optional `travel_time` field per device. This value represents the time in milliseconds a blind takes to move from fully closed to fully open. It allows the firmware to estimate the current position when no feedback is available. The estimated position is printed to the serial console and shown on the OLED display every second while the blind is moving.
+The `1W.json` file now accepts an optional `travel_time` field per device. This value represents the time in milliseconds a blind takes to move from fully closed to fully open. It allows the firmware to estimate the current position when no feedback is available. The estimated position is printed to the serial console and shown on the OLED display every second while the blind is moving. When a command is transmitted or received, this position feedback is appended below the action information on the display so that the original message remains visible.
 
 Example payload for `B60D1A`:
 

--- a/src/oled_display.cpp
+++ b/src/oled_display.cpp
@@ -77,18 +77,26 @@ void display1WPosition(const uint8_t *remote, float position, const char *name) 
     std::string id = bytesToHexString(remote, 3);
     const auto *entry = IOHC::iohcRemoteMap::getInstance()->find(remote);
 
-    display.clearDisplay();
     display.setTextSize(1);
     display.setTextColor(SSD1306_WHITE);
-    display.setCursor(0, 0);
+
+    // Clear only the area used for the position line so existing text remains
+    int y = 30;  // Position feedback shown below action information
+    display.fillRect(0, y, SCREEN_WIDTH, 10, SSD1306_BLACK);
+    display.setCursor(0, y);
+
     if (name) {
-        display.println(name);
+        display.print(name);
+        display.print(" ");
     } else if (entry) {
-        display.println(entry->name.c_str());
+        display.print(entry->name.c_str());
+        display.print(" ");
     } else {
         display.print("ID: ");
-        display.println(id.c_str());
+        display.print(id.c_str());
+        display.print(" ");
     }
+
     display.print("Pos: ");
     display.print(static_cast<int>(position));
     display.println("%");


### PR DESCRIPTION
## Summary
- avoid clearing the screen when showing position updates
- explain that the position feedback now appears below the action display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d46f757088326adc0ecc09aebe1fd