### PR TITLE
Add key to device info in MQTT discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ When MQTT is enabled (`#define MQTT` in `include/user_config.h`) the firmware pu
 
 Each blind configuration is sent to the topic `homeassistant/cover/<id>/config` where `<id>` is the hexadecimal address from `1W.json`.
 
+The discovery payload's `device` section now also exposes the device's AES `key` as read from `1W.json`.
+
 The `1W.json` file now accepts an optional `travel_time` field per device. This value represents the time in milliseconds a blind takes to move from fully closed to fully open. It allows the firmware to estimate the current position when no feedback is available. The estimated position is printed to the serial console and shown on the OLED display every second while the blind is moving. When a command is transmitted or received, this position feedback is appended below the action information on the display so that the original message remains visible.
 If these fields (`name` and `travel_time`) are missing, default values are applied using the device description and a 10 second travel time. These defaults are saved back to `1W.json` so subsequent boots load the updated values automatically.
 Sequence numbers for each remote are stored both in `extras/1W.json` and in NVS.

--- a/include/mqtt_handler.h
+++ b/include/mqtt_handler.h
@@ -23,7 +23,7 @@ void onMqttDisconnect(AsyncMqttClientDisconnectReason reason);
 void onMqttMessage(char *topic, char *payload,
                    AsyncMqttClientMessageProperties properties,
                    size_t len, size_t index, size_t total);
-void publishDiscovery(const std::string &id, const std::string &name);
+void publishDiscovery(const std::string &id, const std::string &name, const std::string &key);
 void handleMqttConnect();
 void publishHeartbeat(TimerHandle_t timer);
 void mqttFuncHandler(const char *cmd);

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -34,7 +34,7 @@ void initMqtt() {
 
 
 
-void publishDiscovery(const std::string &id, const std::string &name) {
+void publishDiscovery(const std::string &id, const std::string &name, const std::string &key) {
     JsonDocument doc;
     doc["name"] = name;
     doc["unique_id"] = id;
@@ -64,6 +64,7 @@ void publishDiscovery(const std::string &id, const std::string &name) {
     device["manufacturer"] = "Somfy";
     device["model"] = "IO Blind Bridge";
     device["sw_version"] = "1.0.0";
+    device["key"] = key;
 
     std::string payload;
     size_t len = serializeJson(doc, payload);
@@ -92,7 +93,8 @@ void handleMqttConnect() {
     const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
     for (const auto &r : remotes) {
         std::string id = bytesToHexString(r.node, sizeof(r.node));
-        publishDiscovery(id, r.name.empty() ? r.description : r.name);
+        std::string key = bytesToHexString(r.key, sizeof(r.key));
+        publishDiscovery(id, r.name.empty() ? r.description : r.name, key);
         std::string t = "iown/" + id + "/set";
         mqttClient.subscribe(t.c_str(), 0);
     }


### PR DESCRIPTION
## Summary
- include AES key from 1W.json in Home Assistant discovery messages
- document the new `key` field

## Testing
- `platformio run` *(fails: blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_687ff6c0c4ec832684978f9362730023