### PR TITLE
Add pairing status tracking for 1W devices

### DIFF
--- a/extras/1W.json
+++ b/extras/1W.json
@@ -8,7 +8,8 @@
         ],
         "manufacturer_id": 2,
         "description": "IZY1",
-        "name": "IZY1"
+        "name": "IZY1",
+        "paired": false
     },
     "b60d1b": {
         "key": "b794883327810507c2a5419eeeae54b4",
@@ -19,7 +20,8 @@
         ],
         "manufacturer_id": 2,
         "description": "IZY2",
-        "name": "IZY2"
+        "name": "IZY2",
+        "paired": false
     },
     "e8e150": {
         "key": "77999e593262e207c8f992904ec4c4f2",
@@ -30,7 +32,8 @@
         ],
         "manufacturer_id": 2,
         "description": "DYNA",
-        "name": "DYNA"
+        "name": "DYNA",
+        "paired": false
     },
     "e00001": {
         "key": "7ab132c95f843da7116ed03b9cf20845",
@@ -41,7 +44,8 @@
         ],
         "manufacturer_id": 2,
         "description": "SUNS",
-        "name": "Luifel Tuin"
+        "name": "Luifel Tuin",
+        "paired": false
     },
     "e00002": {
         "key": "bba24bbb61508fc78c5ad0e57ff66210",
@@ -52,6 +56,7 @@
         ],
         "manufacturer_id": 2,
         "description": "SUNG",
-        "name": "Screen G"
+        "name": "Screen G",
+        "paired": false
     }
 }

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -50,6 +50,7 @@ namespace IOHC {
             uint8_t key[16]{};
             std::vector<uint8_t> type{};
             uint8_t manufacturer{};
+            bool paired{false};
             std::string description;
             std::string name;
         };

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -167,6 +167,7 @@ namespace IOHC {
 //                }
                 _radioInstance->send(packets2send);
                 display1WAction(r.node, remoteButtonToString(cmd), "TX", r.name.c_str());
+                r.paired = true;
                 break;
             }
 
@@ -211,6 +212,7 @@ namespace IOHC {
                 _radioInstance->send(packets2send);
                 //printf("\n");
                 display1WAction(r.node, remoteButtonToString(cmd), "TX", r.name.c_str());
+                r.paired = false;
                 break;
             }
 
@@ -545,6 +547,10 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
             r.manufacturer = jobj["manufacturer_id"].as<uint8_t>();
             r.description = jobj["description"].as<std::string>();
             r.name = jobj["name"].as<std::string>();
+            if (jobj.containsKey("paired"))
+                r.paired = jobj["paired"].as<bool>();
+            else
+                r.paired = false;
             remotes.push_back(r);
         }
 
@@ -581,6 +587,7 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
             jobj["manufacturer_id"] = r.manufacturer;
             jobj["description"] = r.description;
             jobj["name"] = r.name;
+            jobj["paired"] = r.paired;
         }
         serializeJson(doc, f);
         f.close();


### PR DESCRIPTION
## Summary
- track whether each 1W device is paired
- update 1W.json with new `paired` field
- save pairing status when pair/remove commands are issued

## Testing
- `pip install platformio`
- `pio check` *(fails: api.registry.platformio.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883ee4981a48326bab69988072dd19c