### PR TITLE
Add pairing status tracking

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -21,6 +21,7 @@ VARIOUS 1W (Use the description name in 1W.json as argument)
 - **pair**      _1W put device in pair mode_
 - **add**       _1W add controller to device_
 - **remove**    _1W remove controller from device_
+- **pair** and **remove** update the `paired` status in `1W.json`. The field is automatically created with value `false` if it is missing when the file is loaded.
 - **open**      _1W open device_
 - **close**     _1W close device_
 - **stop**      _1W stop device_

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The discovery payload's `device` section now also exposes the device's AES `key`
 
 The `1W.json` file now accepts an optional `travel_time` field per device. This value represents the time in milliseconds a blind takes to move from fully closed to fully open. It allows the firmware to estimate the current position when no feedback is available. The estimated position is printed to the serial console and shown on the OLED display every second while the blind is moving. When a command is transmitted or received, this position feedback is appended below the action information on the display so that the original message remains visible.
 If these fields (`name` and `travel_time`) are missing, default values are applied using the device description and a 10 second travel time. These defaults are saved back to `1W.json` so subsequent boots load the updated values automatically.
+Each entry can also contain a `paired` boolean that indicates if the blind is paired to a screen. If the field is missing, it is automatically added with a default value of `false` when the file is loaded. The flag is updated automatically when the `pair` or `remove` commands are used.
 Sequence numbers for each remote are stored both in `extras/1W.json` and in NVS.
 On boot the value from the file is compared to the one in NVS and the highest
 value is kept so sequence numbers continue uninterrupted even after filesystem

--- a/extras/1W.json
+++ b/extras/1W.json
@@ -9,7 +9,8 @@
         "manufacturer_id": 2,
         "description": "IZY1",
         "name": "IZY1",
-        "travel_time": 10000
+        "travel_time": 10000,
+        "paired": false
     },
     "b60d1b": {
         "key": "b794883327810507c2a5419eeeae54b4",
@@ -21,7 +22,8 @@
         "manufacturer_id": 2,
         "description": "IZY2",
         "name": "IZY2",
-        "travel_time": 10000
+        "travel_time": 10000,
+        "paired": false
     },
     "e8e150": {
         "key": "77999e593262e207c8f992904ec4c4f2",
@@ -33,7 +35,8 @@
         "manufacturer_id": 2,
         "description": "DYNA",
         "name": "DYNA",
-        "travel_time": 10000
+        "travel_time": 10000,
+        "paired": false
     },
     "e00001": {
         "key": "7ab132c95f843da7116ed03b9cf20845",
@@ -45,7 +48,8 @@
         "manufacturer_id": 2,
         "description": "SUNS",
         "name": "Luifel Tuin",
-        "travel_time": 10000
+        "travel_time": 10000,
+        "paired": false
     },
     "e00002": {
         "key": "bba24bbb61508fc78c5ad0e57ff66210",
@@ -57,7 +61,8 @@
         "manufacturer_id": 2,
         "description": "SUNG",
         "name": "Screen G",
-        "travel_time": 10000
+        "travel_time": 10000,
+        "paired": false
     },
     "e00003": {
         "key": "6cd5b149de8a257bf03e0a22e61c0029",
@@ -69,7 +74,8 @@
         "manufacturer_id": 2,
         "description": "SNT1",
         "name": "Screen T2",
-        "travel_time": 10000
+        "travel_time": 10000,
+        "paired": false
     },
     "e00004": {
         "key": "f3a1d67c4b8209eb5d7cf041ea9638b2",
@@ -81,6 +87,7 @@
         "manufacturer_id": 2,
         "description": "SNT2",
         "name": "Screen T1",
-        "travel_time": 10000
+        "travel_time": 10000,
+        "paired": false
     }
 }

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -55,6 +55,7 @@ namespace IOHC {
             std::string description;
             std::string name;
             uint32_t travelTime{}; // ms to fully open or close
+            bool paired{false};
             BlindPosition positionTracker{};
             enum class Movement { Idle, Opening, Closing } movement{Movement::Idle};
             float lastPublishedPosition{-1.0f};

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -189,6 +189,7 @@ namespace IOHC {
 #if defined(SSD1306_DISPLAY)
                 display1WPosition(r.node, r.positionTracker.getPosition(), r.name.c_str());
 #endif
+                r.paired = true;
                 break;
             }
 
@@ -238,6 +239,7 @@ namespace IOHC {
 #if defined(SSD1306_DISPLAY)
                 display1WPosition(r.node, r.positionTracker.getPosition(), r.name.c_str());
 #endif
+                r.paired = false;
                 break;
             }
 
@@ -639,6 +641,12 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
                 r.travelTime = DEFAULT_TRAVEL_TIME_MS;
                 updateFile = true;
             }
+            if (jobj["paired"].is<bool>()) {
+                r.paired = jobj["paired"].as<bool>();
+            } else {
+                r.paired = false;
+                updateFile = true;
+            }
             r.positionTracker.setTravelTime(r.travelTime);
             remotes.push_back(r);
         }
@@ -681,6 +689,7 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
             jobj["description"] = r.description;
             jobj["name"] = r.name;
             jobj["travel_time"] = r.travelTime;
+            jobj["paired"] = r.paired;
         }
         serializeJson(doc, f);
         f.close();


### PR DESCRIPTION
## Summary
- add `paired` field to remote profiles
- update command docs about pairing state
- persist new field in 1W.json
- update README
- mark devices paired/unpaired upon pair/remove
- mention that the paired field is added automatically

## Testing
- `pip install platformio` *(success)*
- `pio run` *(fails: blocked domain)*

------
https://chatgpt.com/codex/tasks/task_e_6883f11aa90c83268c1218145055c1c5