### PR TITLE
Add command to register new 1W device

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -33,6 +33,7 @@ VARIOUS 1W (Use the description name in 1W.json as argument)
 - **mode2**     _1W Mode2_
 - **mode3**     _1W Mode3_
 - **mode4**     _1W Mode4_
+- **new1W**    _Add new 1W device_
 
 COMMON
 - **verbose**   _Toggle verbose output on packets list_

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -73,6 +73,7 @@ namespace IOHC {
         static void forgePacket(iohcPacket* packet, uint16_t typn);
 
         const std::vector<remote>& getRemotes() const;
+        bool addRemote(const std::string &name);
         void updatePositions();
 
     private:

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -125,6 +125,13 @@ void createCommands() {
     Cmd::addHandler((char *) "mode4", (char *) "1W Mode4", [](Tokens *cmd)-> void {
         IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Mode4, cmd);
     });
+    Cmd::addHandler((char *) "new1W", (char *) "Add new 1W device", [](Tokens *cmd)-> void {
+        if (cmd->size() < 2) {
+            Serial.println("Usage: new1W <name>");
+            return;
+        }
+        IOHC::iohcRemote1W::getInstance()->addRemote(cmd->at(1));
+    });
     // Other 2W
     Cmd::addHandler((char *) "discovery", (char *) "Send discovery on air", [](Tokens *cmd)-> void {
         IOHC::iohcOtherDevice2W::getInstance()->cmd(IOHC::Other2WButton::discovery, nullptr);


### PR DESCRIPTION
## Summary
- add `addRemote()` helper to create new 1W devices
- expose helper in `iohcRemote1W` header
- register `new1W` console command
- document command in COMMANDS.md

## Testing
- `trunk check` *(fails: command not found)*
- `pio run -t size` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883f8d771f08326b986b3aa42dcc67e