### PR TITLE
fix: load devices before web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ This project now includes an experimental web interface to control IOHC devices.
         *   First, build the filesystem image: `pio run --target buildfs` (or use the PlatformIO IDE option for building the filesystem image).
         *   Then, upload the filesystem image: `pio run --target uploadfs` (or use the PlatformIO IDE option for uploading).
     *   **Note:** You only need to rebuild and re-upload the filesystem image if you make changes to the files in `extras/web_interface_data/`.
+    *   **Device files:** Copy your device definition files (for example `extras/1W.json`) into the LittleFS root before building.
+        Without these files the `/api/devices` endpoint returns an empty list and the web interface will show no devices.
 
 3.  **Build and Upload Firmware:**
     *   Build and upload the main firmware to your ESP32 as usual using PlatformIO (`pio run --target upload` or via the IDE).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,6 +107,9 @@ void setup() {
 #if defined(MQTT)
     initMqtt();
 #endif
+    // Load 1W device definitions before starting the web server so
+    // that /api/devices can immediately return the configured remotes.
+    remote1W = IOHC::iohcRemote1W::getInstance();
 #if defined(WEBSERVER)
     setupWebServer();
 #endif
@@ -117,7 +120,6 @@ void setup() {
 
     sysTable = IOHC::iohcSystemTable::getInstance();
 
-    remote1W = IOHC::iohcRemote1W::getInstance();
     cozyDevice2W = IOHC::iohcCozyDevice2W::getInstance();
     otherDevice2W = IOHC::iohcOtherDevice2W::getInstance();
     remoteMap = IOHC::iohcRemoteMap::getInstance();


### PR DESCRIPTION
## Summary
- initialize 1W device definitions before launching the web server so `/api/devices` returns configured remotes

## Testing
- `pio run -t check -e LilyGoLoraESP32` *(fails: HTTPClientError)*
- `curl -fsSL https://get.trunk.io -o /tmp/install-trunk.sh && sh /tmp/install-trunk.sh -y` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_e_689247b56cc483268c20714b7e12af85