### PR TITLE
Add CLI command to delete 1W devices

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -34,6 +34,7 @@ VARIOUS 1W (Use the description name in 1W.json as argument)
 - **mode3**     _1W Mode3_
 - **mode4**     _1W Mode4_
 - **new1W**    _Add new 1W device_
+- **del1W**    _Remove 1W device_
 
 COMMON
 - **verbose**   _Toggle verbose output on packets list_

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -74,6 +74,7 @@ namespace IOHC {
 
         const std::vector<remote>& getRemotes() const;
         bool addRemote(const std::string &name);
+        bool removeRemote(const std::string &description);
         void updatePositions();
 
     private:

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -132,6 +132,13 @@ void createCommands() {
         }
         IOHC::iohcRemote1W::getInstance()->addRemote(cmd->at(1));
     });
+    Cmd::addHandler((char *) "del1W", (char *) "Remove 1W device", [](Tokens *cmd)-> void {
+        if (cmd->size() < 2) {
+            Serial.println("Usage: del1W <description>");
+            return;
+        }
+        IOHC::iohcRemote1W::getInstance()->removeRemote(cmd->at(1));
+    });
     // Other 2W
     Cmd::addHandler((char *) "discovery", (char *) "Send discovery on air", [](Tokens *cmd)-> void {
         IOHC::iohcOtherDevice2W::getInstance()->cmd(IOHC::Other2WButton::discovery, nullptr);

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -745,6 +745,23 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
         return true;
     }
 
+    bool iohcRemote1W::removeRemote(const std::string &description) {
+        auto it = std::find_if(remotes.begin(), remotes.end(), [&](const remote &e) {
+            return e.description == description;
+        });
+        if (it == remotes.end()) {
+            Serial.printf("Device %s not found\n", description.c_str());
+            return false;
+        }
+        if (it->paired) {
+            Serial.println("WARNING: Device is paired. Unpair before removing.");
+            return false;
+        }
+        remotes.erase(it);
+        save();
+        return true;
+    }
+
     void iohcRemote1W::updatePositions() {
         for (auto &r : remotes) {
             r.positionTracker.update();


### PR DESCRIPTION
## Summary
- allow 1W remotes to be removed from configuration when unpaired
- expose new `del1W` command to delete unpaired devices from 1W.json
- document CLI command for removing devices

## Testing
- `pio test` *(fails: test folder does not exist)*
- `pio run` *(fails: HTTPClientError while installing platform)*

------
https://chatgpt.com/codex/tasks/task_e_6893a57b37448326ac52701b1bac1a46