### PR TITLE
feat: allow renaming 1w devices

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -35,6 +35,7 @@ VARIOUS 1W (Use the description name in 1W.json as argument)
 - **mode4**     _1W Mode4_
 - **new1W**    _Add new 1W device_
 - **del1W**    _Remove 1W device_
+- **edit1W**   _Edit 1W device name_
 - **list1W**   _List 1W devices_
 
 COMMON

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -75,6 +75,7 @@ namespace IOHC {
         const std::vector<remote>& getRemotes() const;
         bool addRemote(const std::string &name);
         bool removeRemote(const std::string &description);
+        bool renameRemote(const std::string &description, const std::string &name);
         void updatePositions();
 
     private:

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -139,6 +139,13 @@ void createCommands() {
         }
         IOHC::iohcRemote1W::getInstance()->removeRemote(cmd->at(1));
     });
+    Cmd::addHandler((char *) "edit1W", (char *) "Edit 1W device name", [](Tokens *cmd)-> void {
+        if (cmd->size() < 3) {
+            Serial.println("Usage: edit1W <description> <name>");
+            return;
+        }
+        IOHC::iohcRemote1W::getInstance()->renameRemote(cmd->at(1), cmd->at(2));
+    });
     Cmd::addHandler((char *) "list1W", (char *) "List 1W devices", [](Tokens *cmd)-> void {
         const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
         for (const auto &r : remotes) {

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -762,6 +762,19 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
         return true;
     }
 
+    bool iohcRemote1W::renameRemote(const std::string &description, const std::string &name) {
+        auto it = std::find_if(remotes.begin(), remotes.end(), [&](const remote &e) {
+            return e.description == description;
+        });
+        if (it == remotes.end()) {
+            Serial.printf("Device %s not found\n", description.c_str());
+            return false;
+        }
+        it->name = name;
+        save();
+        return true;
+    }
+
     void iohcRemote1W::updatePositions() {
         for (auto &r : remotes) {
             r.positionTracker.update();


### PR DESCRIPTION
## Summary
- support renaming a 1W device via new `edit1W` command
- persist updated name in configuration

## Testing
- `pio run` *(fails: HTTPClientError:)*

------
https://chatgpt.com/codex/tasks/task_e_6893a9fd47f08326bfe7a55abd8db24f