### PR TITLE
feat: add MQTT configuration commands

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -41,3 +41,10 @@ VARIOUS 1W (Use the description name in 1W.json as argument)
 COMMON
 - **verbose**   _Toggle verbose output on packets list_
 - **help**      _This command_
+- **ls**        _List filesystem_
+- **cat**       _Print file content_
+- **rm**        _Remove file_
+- **mqttIp**    _Set MQTT server IP_
+- **mqttUser**  _Set MQTT username_
+- **mqttPass**  _Set MQTT password_
+- **mqttDiscovery** _Set MQTT discovery topic_

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The discovery topics are:
 Sending `PRESS` to `iown/<id>/pair`, `iown/<id>/add` or `iown/<id>/remove`
 triggers the corresponding command on the blind.
 
-Configure your MQTT broker settings in `include/user_config.h` (`MQTT_SERVER`, `MQTT_USER`, `MQTT_PASSWD`). After boot and connection, Home Assistant should automatically discover the covers.
+Configure your MQTT broker settings in `include/user_config.h` (`mqtt_server`, `mqtt_user`, `mqtt_password`, `mqtt_discovery_topic`). These values can also be changed at runtime via the `mqttIp`, `mqttUser`, `mqttPass` and `mqttDiscovery` commands. After boot and connection, Home Assistant should automatically discover the covers.
 
 If you don't have an OLED display connected, comment out the `DISPLAY` definition in `include/user_config.h` to disable all display related code.
 

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -18,6 +18,7 @@
 #define IOHC_USER_H
 
 #include <board-config.h>
+#include <string>
 
 // WiFi credentials are handled via WiFiManager
 #define WIFI_SSID ""
@@ -26,12 +27,13 @@ inline const char *wifi_ssid = "";
 inline const char *wifi_passwd = "";
 
 #define MQTT
-#define MQTT_SERVER "XX"
-#define MQTT_USER "mosquitto"
-#define MQTT_PASSWD "XX"
-//inline const char *mqtt_server = "192.168.1.40";
-//inline const char *mqtt_user = "user";
-//inline const char *mqtt_password = "passwd";
+
+// Default MQTT configuration. These values can be changed at runtime through
+// the interactive command interface.
+inline std::string mqtt_server = "XX";
+inline std::string mqtt_user = "mosquitto";
+inline std::string mqtt_password = "XX";
+inline std::string mqtt_discovery_topic = "homeassistant";
 
 // Comment out the next line if no display is connected
 #define SSD1306_DISPLAY

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -200,6 +200,47 @@ void createCommands() {
     Cmd::addHandler((char *) "ls", (char *) "List filesystem", [](Tokens *cmd)-> void { listFS(); });
     Cmd::addHandler((char *) "cat", (char *) "Print file content", [](Tokens *cmd)-> void { cat(cmd->at(1).c_str()); });
     Cmd::addHandler((char *) "rm", (char *) "Remove file", [](Tokens *cmd)-> void { rm(cmd->at(1).c_str()); });
+#if defined(MQTT)
+    Cmd::addHandler((char *) "mqttIp", (char *) "Set MQTT server IP", [](Tokens *cmd)-> void {
+        if (cmd->size() < 2) {
+            Serial.println("Usage: mqttIp <ip>");
+            return;
+        }
+        mqtt_server = cmd->at(1);
+        mqttClient.disconnect();
+        mqttClient.setServer(mqtt_server.c_str(), 1883);
+        connectToMqtt();
+    });
+    Cmd::addHandler((char *) "mqttUser", (char *) "Set MQTT username", [](Tokens *cmd)-> void {
+        if (cmd->size() < 2) {
+            Serial.println("Usage: mqttUser <username>");
+            return;
+        }
+        mqtt_user = cmd->at(1);
+        mqttClient.disconnect();
+        mqttClient.setCredentials(mqtt_user.c_str(), mqtt_password.c_str());
+        connectToMqtt();
+    });
+    Cmd::addHandler((char *) "mqttPass", (char *) "Set MQTT password", [](Tokens *cmd)-> void {
+        if (cmd->size() < 2) {
+            Serial.println("Usage: mqttPass <password>");
+            return;
+        }
+        mqtt_password = cmd->at(1);
+        mqttClient.disconnect();
+        mqttClient.setCredentials(mqtt_user.c_str(), mqtt_password.c_str());
+        connectToMqtt();
+    });
+    Cmd::addHandler((char *) "mqttDiscovery", (char *) "Set MQTT discovery topic", [](Tokens *cmd)-> void {
+        if (cmd->size() < 2) {
+            Serial.println("Usage: mqttDiscovery <topic>");
+            return;
+        }
+        mqtt_discovery_topic = cmd->at(1);
+        if (mqttStatus == ConnState::Connected)
+            handleMqttConnect();
+    });
+#endif
 /*
     Cmd::addHandler((char *) "list2W", (char *) "List received packets", [](Tokens *cmd)-> void {
         for (uint8_t i = 0; i < nextPacket; i++) msgRcvd(radioPackets[i]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -602,7 +602,7 @@ bool publishMsg(IOHC::iohcPacket *iohc) {
     size_t messageSize = serializeJson(doc, message);
 #if defined(MQTT)
     mqttClient.publish("iown/Frame", 1, false, message.c_str(), messageSize);
-    mqttClient.publish("homeassistant/sensor/iohc_frame/state", 0, false, message.c_str(), messageSize);
+    mqttClient.publish((mqtt_discovery_topic + "/sensor/iohc_frame/state").c_str(), 0, false, message.c_str(), messageSize);
 #endif
     return false;
 }


### PR DESCRIPTION
## Summary
- allow runtime update of MQTT server, credentials and discovery topic
- document new MQTT commands

## Testing
- `pip install platformio`
- `pio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_6893b1d96b688326a3320695197c523f