### PR TITLE
feat: add 1W travel time command

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -36,6 +36,7 @@ VARIOUS 1W (Use the description name in 1W.json as argument)
 - **new1W**    _Add new 1W device_
 - **del1W**    _Remove 1W device_
 - **edit1W**   _Edit 1W device name_
+- **time1W**   _Set 1W device travel time_
 - **list1W**   _List 1W devices_
 
 COMMON

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -76,6 +76,7 @@ namespace IOHC {
         bool addRemote(const std::string &name);
         bool removeRemote(const std::string &description);
         bool renameRemote(const std::string &description, const std::string &name);
+        bool setTravelTime(const std::string &description, uint32_t travelTime);
         void updatePositions();
 
     private:

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -21,6 +21,7 @@
 #include <wifi_helper.h>
 #include <oled_display.h>
 #include <iohcCryptoHelpers.h>
+#include <cstdlib>
 #if defined(MQTT)
 #include <mqtt_handler.h>
 #endif
@@ -145,6 +146,14 @@ void createCommands() {
             return;
         }
         IOHC::iohcRemote1W::getInstance()->renameRemote(cmd->at(1), cmd->at(2));
+    });
+    Cmd::addHandler((char *) "time1W", (char *) "Set 1W device travel time", [](Tokens *cmd)-> void {
+        if (cmd->size() < 3) {
+            Serial.println("Usage: time1W <description> <ms>");
+            return;
+        }
+        uint32_t t = strtoul(cmd->at(2).c_str(), nullptr, 10);
+        IOHC::iohcRemote1W::getInstance()->setTravelTime(cmd->at(1), t);
     });
     Cmd::addHandler((char *) "list1W", (char *) "List 1W devices", [](Tokens *cmd)-> void {
         const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -775,6 +775,20 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
         return true;
     }
 
+    bool iohcRemote1W::setTravelTime(const std::string &description, uint32_t travelTime) {
+        auto it = std::find_if(remotes.begin(), remotes.end(), [&](const remote &e) {
+            return e.description == description;
+        });
+        if (it == remotes.end()) {
+            Serial.printf("Device %s not found\n", description.c_str());
+            return false;
+        }
+        it->travelTime = travelTime;
+        it->positionTracker.setTravelTime(travelTime);
+        save();
+        return true;
+    }
+
     void iohcRemote1W::updatePositions() {
         for (auto &r : remotes) {
             r.positionTracker.update();


### PR DESCRIPTION
## Summary
- allow updating a 1W blind's open/close travel time via new `time1W` command
- persist travel time in JSON configuration and adjust runtime tracking
- document new command

## Testing
- `pio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_6893bbfb2d688326ae41aabb8e26f091