### PR TITLE
Handle sequential MQTT discovery and dynamic device updates

### DIFF
--- a/include/mqtt_handler.h
+++ b/include/mqtt_handler.h
@@ -29,6 +29,7 @@ void publishHeartbeat(TimerHandle_t timer);
 void mqttFuncHandler(const char *cmd);
 void publishCoverState(const std::string &id, const char *state);
 void publishCoverPosition(const std::string &id, float position);
+void removeDiscovery(const std::string &id);
 
 #endif // MQTT
 


### PR DESCRIPTION
## Summary
- Avoid MQTT buffer flooding by pacing discovery messages with a delay
- Publish and unpublish discovery topics when devices are added or removed
- Expose helper to clear MQTT discovery entries

## Testing
- `platformio run` *(fails: aborted while installing `espressif32` platform)*

------
https://chatgpt.com/codex/tasks/task_e_689644ecea3883269d17b25548768254