### PR TITLE
Refine MQTT reconnect handling

### DIFF
--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -65,9 +65,9 @@ void connectToWifi() {
         wifiStatus = ConnState::Connected;
         updateDisplayStatus();
 #if defined(MQTT)
-        // Kick off MQTT connection when WiFi becomes available
-        if (mqttReconnectTimer) {
-            xTimerStart(mqttReconnectTimer, 0);
+        // Establish MQTT connection if needed
+        if (!mqttClient.connected() && mqttStatus != ConnState::Connecting) {
+            connectToMqtt();
         }
 #endif
     }


### PR DESCRIPTION
## Summary
- remove automatic MQTT connection from initialization
- connect to MQTT only after Wi-Fi is established and no connection is in progress
- guard against concurrent MQTT reconnect attempts

## Testing
- `pio run -e HeltecLoraV2ESP32` *(failed: Platform Manager stalled installing espressif32)*

------
https://chatgpt.com/codex/tasks/task_e_689655e004888326bcb70ffd016c7282