### PR TITLE
Refactor WiFi reconnect callback

### DIFF
--- a/include/wifi_helper.h
+++ b/include/wifi_helper.h
@@ -25,7 +25,7 @@ extern TimerHandle_t wifiReconnectTimer;
 extern ConnState wifiStatus;
 
 void initWifi();
-void connectToWifi();
+void connectToWifi(TimerHandle_t timer = nullptr);
 void checkWifiConnection();
 
 #endif // WIFI_HELPER_H

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -32,15 +32,15 @@ void initWifi() {
         pdMS_TO_TICKS(10000),  // 10 seconds retry interval
         pdFALSE,
         nullptr,
-        reinterpret_cast<TimerCallbackFunction_t>(connectToWifi)
+        connectToWifi
     );
     if (!wifiReconnectTimer) {
         Serial.println("Failed to create WiFi reconnect timer");
     }
-    connectToWifi();
+    connectToWifi(nullptr);
 }
 
-void connectToWifi() {
+void connectToWifi(TimerHandle_t /*timer*/) {
     Serial.println("Connecting to Wi-Fi via WiFiManager...");
     wifiStatus = ConnState::Connecting;
     updateDisplayStatus();


### PR DESCRIPTION
## Summary
- Adjust Wi-Fi reconnection flow so the timer callback matches `TimerCallbackFunction_t`.
- Remove `reinterpret_cast` and call the reconnect function directly from `xTimerCreate`.
- Timer still starts after failed WiFiManager connections.

## Testing
- `pio run` *(fails: HTTPClientError while installing espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_689658c572288326b5bedfdbaebe3f08