### PR TITLE
fix: ensure mqtt init triggers connection

### DIFF
--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -30,6 +30,9 @@ void initMqtt() {
     mqttReconnectTimer = xTimerCreate("mqttTimer", pdMS_TO_TICKS(5000), pdFALSE,
                                       nullptr,
                                       reinterpret_cast<TimerCallbackFunction_t>(connectToMqtt));
+    if (WiFi.status() == WL_CONNECTED) {
+        connectToMqtt();
+    }
 }
 
 

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -65,8 +65,9 @@ void connectToWifi() {
         wifiStatus = ConnState::Connected;
         updateDisplayStatus();
 #if defined(MQTT)
-        // Establish MQTT connection if needed
-        if (!mqttClient.connected() && mqttStatus != ConnState::Connecting) {
+        // Establish MQTT connection if needed and MQTT client is initialized
+        if (mqttReconnectTimer && !mqttClient.connected() &&
+            mqttStatus != ConnState::Connecting) {
             connectToMqtt();
         }
 #endif


### PR DESCRIPTION
## Summary
- prevent WiFi helper from calling MQTT connect before client init
- attempt MQTT connection once MQTT client is initialized

## Testing
- `pio run` *(fails: Platform Manager: Installing espressif32)*

------
https://chatgpt.com/codex/tasks/task_e_68965d4c2eb883269eb9fff19fdb6869