### PR TITLE
Add mDNS discovery for mioopenio.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This project now includes an experimental web interface to control IOHC devices.
 
 5.  **Access the Interface:**
     *   Open a web browser on a device connected to the same WiFi network as your ESP32.
-    *   Navigate to the IP address you found in the Serial Monitor (e.g., `http://XXX.XXX.X.XXX`).
+    *   Navigate to the IP address you found in the Serial Monitor (e.g., `http://XXX.XXX.X.XXX`) or use `http://mioopenio.local` if your network supports mDNS.
 
 ### Usage
 

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -21,6 +21,7 @@
 #include <mqtt_handler.h>
 #endif
 #include <WiFiManager.h>
+#include <ESPmDNS.h>
 
 TimerHandle_t wifiReconnectTimer;
 
@@ -64,6 +65,12 @@ void connectToWifi(TimerHandle_t /*timer*/) {
         Serial.printf("Connected to WiFi. IP address: %s\n", WiFi.localIP().toString().c_str());
         wifiStatus = ConnState::Connected;
         updateDisplayStatus();
+
+        if (!MDNS.begin("mioopenio")) {
+            Serial.println("Error setting up MDNS responder!");
+        } else {
+            Serial.println("MDNS responder started at http://mioopenio.local");
+        }
 #if defined(MQTT)
         // Establish MQTT connection if needed and MQTT client is initialized
         if (mqttReconnectTimer && !mqttClient.connected() &&


### PR DESCRIPTION
## Summary
- enable mDNS responder with hostname `mioopenio` so the device answers at `mioopenio.local`
- document the new `mioopenio.local` address in the web interface instructions

## Testing
- `cppcheck src/wifi_helper.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6898712ff0988326901c0b4372d2ff29