### PR TITLE
Persist MQTT configuration via NVS

### DIFF
--- a/include/nvs_helpers.h
+++ b/include/nvs_helpers.h
@@ -2,9 +2,13 @@
 #define NVS_HELPERS_H
 
 #include <iohcPacket.h>
+#include <string>
 
 bool nvs_init();
 bool nvs_read_sequence(const IOHC::address addr, uint16_t *sequence);
 void nvs_write_sequence(const IOHC::address addr, uint16_t sequence);
+
+bool nvs_read_string(const char *key, std::string &value);
+void nvs_write_string(const char *key, const std::string &value);
 
 #endif // NVS_HELPERS_H

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -29,10 +29,10 @@ inline const char *wifi_passwd = "";
 #define MQTT
 
 // Default MQTT configuration. These values can be changed at runtime through
-// the interactive command interface.
-inline std::string mqtt_server = "XX";
+// the interactive command interface. Leave empty to rely on stored values.
+inline std::string mqtt_server = "";
 inline std::string mqtt_user = "mosquitto";
-inline std::string mqtt_password = "XX";
+inline std::string mqtt_password = "";
 inline std::string mqtt_discovery_topic = "homeassistant";
 
 // Comment out the next line if no display is connected

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -25,6 +25,7 @@
 #if defined(MQTT)
 #include <mqtt_handler.h>
 #endif
+#include <nvs_helpers.h>
 
 ConnState mqttStatus = ConnState::Disconnected;
 
@@ -216,6 +217,7 @@ void createCommands() {
             return;
         }
         mqtt_server = cmd->at(1);
+        nvs_write_string("mqtt_server", mqtt_server);
         mqttClient.disconnect();
         mqttClient.setServer(mqtt_server.c_str(), 1883);
         connectToMqtt();
@@ -226,6 +228,7 @@ void createCommands() {
             return;
         }
         mqtt_user = cmd->at(1);
+        nvs_write_string("mqtt_user", mqtt_user);
         mqttClient.disconnect();
         mqttClient.setCredentials(mqtt_user.c_str(), mqtt_password.c_str());
         connectToMqtt();
@@ -236,6 +239,7 @@ void createCommands() {
             return;
         }
         mqtt_password = cmd->at(1);
+        nvs_write_string("mqtt_password", mqtt_password);
         mqttClient.disconnect();
         mqttClient.setCredentials(mqtt_user.c_str(), mqtt_password.c_str());
         connectToMqtt();
@@ -246,6 +250,7 @@ void createCommands() {
             return;
         }
         mqtt_discovery_topic = cmd->at(1);
+        nvs_write_string("mqtt_discovery_topic", mqtt_discovery_topic);
         if (mqttStatus == ConnState::Connected)
             handleMqttConnect();
     });

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -12,6 +12,7 @@
 #include <WiFi.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
+#include <nvs_helpers.h>
 
 AsyncMqttClient mqttClient;
 TimerHandle_t mqttReconnectTimer;
@@ -19,6 +20,35 @@ TimerHandle_t heartbeatTimer;
 const char AVAILABILITY_TOPIC[] = "iown/status";
 
 void initMqtt() {
+    if (mqtt_server.empty()) {
+        if (!nvs_read_string("mqtt_server", mqtt_server)) {
+            Serial.println("MQTT server not set");
+        }
+    } else {
+        nvs_write_string("mqtt_server", mqtt_server);
+    }
+    if (mqtt_user.empty()) {
+        if (!nvs_read_string("mqtt_user", mqtt_user)) {
+            Serial.println("MQTT user not set");
+        }
+    } else {
+        nvs_write_string("mqtt_user", mqtt_user);
+    }
+    if (mqtt_password.empty()) {
+        if (!nvs_read_string("mqtt_password", mqtt_password)) {
+            Serial.println("MQTT password not set");
+        }
+    } else {
+        nvs_write_string("mqtt_password", mqtt_password);
+    }
+    if (mqtt_discovery_topic.empty()) {
+        if (!nvs_read_string("mqtt_discovery_topic", mqtt_discovery_topic)) {
+            Serial.println("MQTT discovery topic not set");
+        }
+    } else {
+        nvs_write_string("mqtt_discovery_topic", mqtt_discovery_topic);
+    }
+
     mqttClient.setWill(AVAILABILITY_TOPIC, 0, true, "offline");
     mqttClient.setClientId("iown");
     mqttClient.setCredentials(mqtt_user.c_str(), mqtt_password.c_str());

--- a/src/nvs_helpers.cpp
+++ b/src/nvs_helpers.cpp
@@ -26,3 +26,15 @@ void nvs_write_sequence(const IOHC::address addr, uint16_t sequence) {
     sprintf(key, "%02x%02x%02x", addr[0], addr[1], addr[2]);
     prefs.putUShort(key, sequence);
 }
+
+bool nvs_read_string(const char *key, std::string &value) {
+    if (!nvs_init()) return false;
+    if (!prefs.isKey(key)) return false;
+    value = std::string(prefs.getString(key, "").c_str());
+    return true;
+}
+
+void nvs_write_string(const char *key, const std::string &value) {
+    if (!nvs_init()) return;
+    prefs.putString(key, value.c_str());
+}


### PR DESCRIPTION
## Summary
- store default MQTT settings in user config
- add NVS helpers to save and load string values
- load MQTT settings from NVS on startup and persist interactive updates
- remove hard-coded MQTT server and password defaults from user config

## Testing
- `pio run` *(fails: command not found: pio)*

------
https://chatgpt.com/codex/tasks/task_e_689873def72c83268f4e2fae6032a4f7