### PR TITLE
Link Add Device popup to internal command

### DIFF
--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -270,10 +270,24 @@ document.addEventListener('DOMContentLoaded', function() {
       addpopup.addEventListener('click', () => {
          openPopup('Add Device', "new device", null, {
            showInput: true,
-           onConfirm: (newName) => {
+           onConfirm: async (newName) => {
              if (newName.trim()) {
-               console.log('New Device:', newName);
-               // Here you can make an API call or add the device to your list
+               try {
+                 const response = await fetch('/api/command', {
+                   method: 'POST',
+                   headers: { 'Content-Type': 'application/json' },
+                   body: JSON.stringify({ command: `new1W ${newName}` })
+                 });
+                 const result = await response.json();
+                 if (result.success) {
+                   logStatus(result.message || 'Device added.');
+                   fetchAndDisplayDevices();
+                 } else {
+                   logStatus(result.message || 'Failed to add device.', true);
+                 }
+               } catch (e) {
+                 logStatus(`Error adding device: ${e.message}`, true);
+               }
              }
            }
          });


### PR DESCRIPTION
## Summary
- Execute backend command handlers through `/api/command`, allowing optional device IDs and logging results
- Wire Add Device popup to call the new `/api/command` endpoint to create 1W devices and refresh the device list

## Testing
- `pio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68987737669c83268ff086b9f110acaf