### PR TITLE
Republish MQTT discovery on device rename

### DIFF
--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -801,6 +801,13 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
         }
         it->name = name;
         save();
+#if defined(MQTT)
+        if (mqttClient.connected()) {
+            std::string id = bytesToHexString(it->node, sizeof(it->node));
+            std::string key = bytesToHexString(it->key, sizeof(it->key));
+            publishDiscovery(id, it->name, key);
+        }
+#endif
         return true;
     }
 


### PR DESCRIPTION
## Summary
- Refresh Home Assistant MQTT discovery when a device is renamed

## Testing
- `platformio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_689888474a1c832697f70faff29d9a4f