### PR TITLE
Add MQTT configuration UI and API

### DIFF
--- a/extras/web_interface_data/index.html
+++ b/extras/web_interface_data/index.html
@@ -29,7 +29,11 @@
             <section id="device-list-section">
                 <div class="title"><h2>test</h2></div>
                 <div class="card">
-                    
+                    <input type="text" id="mqtt-user" placeholder="MQTT User">
+                    <input type="text" id="mqtt-server" placeholder="MQTT Server">
+                    <input type="password" id="mqtt-password" placeholder="MQTT Password">
+                    <input type="text" id="mqtt-discovery" placeholder="Discovery Topic">
+                    <button id="mqtt-update">Update</button>
                 </div>
             </section>
         </div>


### PR DESCRIPTION
## Summary
- Add MQTT settings inputs and update button to test section of web UI
- Fetch and update MQTT broker configuration via new `/api/mqtt` endpoint
- Expose API handlers to read and persist MQTT configuration changes

## Testing
- `pio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68988ae0b49c83269b414ba67d7b604d