### PR TITLE
Separate cover and button discovery per device

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ The discovery topics are:
 - `homeassistant/button/<id>_add/config`
 - `homeassistant/button/<id>_remove/config`
 
+Each blind along with its control buttons is exposed as an individual device in
+Home Assistant, so the gateway no longer groups all entities into a single
+device list.
+
 Sending `PRESS` to `iown/<id>/pair`, `iown/<id>/add` or `iown/<id>/remove`
 triggers the corresponding command on the blind.
 


### PR DESCRIPTION
## Summary
- publish covers and control buttons as individual devices in Home Assistant
- document that each blind is exposed as its own device

## Testing
- `pio run` *(fails: HTTPClientError while installing espressif32)*

------
https://chatgpt.com/codex/tasks/task_e_689892c1546483268cf9c320c8f64d25