### PR TITLE
feat: expose travel time number entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The discovery payload's `device` section now also exposes the device's AES `key`
 The `1W.json` file now accepts an optional `travel_time` field per device. This value represents the time in milliseconds a blind takes to move from fully closed to fully open. It allows the firmware to estimate the current position when no feedback is available. The estimated position is printed to the serial console and shown on the OLED display every second while the blind is moving. When a command is transmitted or received, this position feedback is appended below the action information on the display so that the original message remains visible.
 If these fields (`name` and `travel_time`) are missing, default values are applied using the device description and a 10 second travel time. These defaults are saved back to `1W.json` so subsequent boots load the updated values automatically.
 
+Each blind also publishes a Home Assistant number entity for the travel time. Adjusting this entity updates the `travel_time` value in `1W.json`, allowing calibration directly from the Home Assistant UI without editing files manually.
+
 Each entry can also contain a `paired` boolean that indicates if the blind is paired to a screen. If the field is missing, it is automatically added with a default value of `false` when the file is loaded. The flag is updated automatically when the `pair` or `remove` commands are used.
 
 Sequence numbers for each remote are stored both in `extras/1W.json` and in NVS.

--- a/include/mqtt_handler.h
+++ b/include/mqtt_handler.h
@@ -25,6 +25,8 @@ void onMqttMessage(char *topic, char *payload,
                    AsyncMqttClientMessageProperties properties,
                    size_t len, size_t index, size_t total);
 void publishDiscovery(const std::string &id, const std::string &name, const std::string &key);
+void publishTravelTimeDiscovery(const std::string &id, const std::string &name,
+                                const std::string &key, uint32_t travelTime);
 void handleMqttConnect();
 void publishHeartbeat(TimerHandle_t timer);
 void mqttFuncHandler(const char *cmd);

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -755,10 +755,12 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
             std::string id = bytesToHexString(r.node, sizeof(r.node));
             std::string key = bytesToHexString(r.key, sizeof(r.key));
             publishDiscovery(id, r.name, key);
+            publishTravelTimeDiscovery(id, r.name, key, r.travelTime);
             mqttClient.subscribe(("iown/" + id + "/set").c_str(), 0);
             mqttClient.subscribe(("iown/" + id + "/pair").c_str(), 0);
             mqttClient.subscribe(("iown/" + id + "/add").c_str(), 0);
             mqttClient.subscribe(("iown/" + id + "/remove").c_str(), 0);
+            mqttClient.subscribe(("iown/" + id + "/travel_time/set").c_str(), 0);
         }
 #endif
         return true;
@@ -784,6 +786,8 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
             mqttClient.unsubscribe(("iown/" + id + "/pair").c_str());
             mqttClient.unsubscribe(("iown/" + id + "/add").c_str());
             mqttClient.unsubscribe(("iown/" + id + "/remove").c_str());
+            mqttClient.unsubscribe(("iown/" + id + "/travel_time/set").c_str());
+            mqttClient.publish(("iown/" + id + "/travel_time").c_str(), 0, true, "", 0);
         }
 #endif
         remotes.erase(it);
@@ -806,6 +810,7 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
             std::string id = bytesToHexString(it->node, sizeof(it->node));
             std::string key = bytesToHexString(it->key, sizeof(it->key));
             publishDiscovery(id, it->name, key);
+            publishTravelTimeDiscovery(id, it->name, key, it->travelTime);
         }
 #endif
         return true;

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -9,6 +9,7 @@
 #include <interact.h>
 #include <oled_display.h>
 #include <cstring>
+#include <cstdlib>
 #include <WiFi.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -90,6 +91,39 @@ static void publishButtonDiscovery(const std::string &id, const std::string &nam
     mqttClient.publish(topic.c_str(), 0, true, payload.c_str(), len);
 }
 
+void publishTravelTimeDiscovery(const std::string &id, const std::string &name,
+                                const std::string &key, uint32_t travelTime) {
+    JsonDocument doc;
+    doc["name"] = name + " travel time";
+    doc["unique_id"] = id + "_travel_time";
+    doc["command_topic"] = "iown/" + id + "/travel_time/set";
+    doc["state_topic"] = "iown/" + id + "/travel_time";
+    doc["unit_of_measurement"] = "ms";
+    doc["min"] = 0;
+    doc["max"] = 60000;
+    doc["step"] = 100;
+
+    JsonObject device = doc["device"].to<JsonObject>();
+    device["identifiers"] = id;
+    device["name"] = name;
+    device["manufacturer"] = "Somfy";
+    device["model"] = "IO Blind Bridge";
+    device["sw_version"] = "1.0.0";
+    device["serial_number"] = key;
+    device["via_device"] = GATEWAY_ID;
+
+    std::string payload;
+    size_t len = serializeJson(doc, payload);
+
+    std::string topic = mqtt_discovery_topic + "/number/" + id + "_travel_time/config";
+    mqttClient.publish(topic.c_str(), 0, true, payload.c_str(), len);
+
+    // publish current value
+    std::string stateTopic = "iown/" + id + "/travel_time";
+    std::string value = std::to_string(travelTime);
+    mqttClient.publish(stateTopic.c_str(), 0, true, value.c_str());
+}
+
 void publishDiscovery(const std::string &id, const std::string &name, const std::string &key) {
     JsonDocument doc;
     doc["name"] = name;
@@ -146,6 +180,9 @@ void removeDiscovery(const std::string &id) {
     removeButton("pair");
     removeButton("add");
     removeButton("remove");
+
+    std::string t = mqtt_discovery_topic + "/number/" + id + "_travel_time/config";
+    mqttClient.publish(t.c_str(), 0, true, "", 0);
 }
 
 void publishHeartbeat(TimerHandle_t) {
@@ -192,12 +229,15 @@ static void handleMqttConnectImpl() {
     for (const auto &r : remotes) {
         std::string id = bytesToHexString(r.node, sizeof(r.node));
         std::string key = bytesToHexString(r.key, sizeof(r.key));
-        publishDiscovery(id, r.name.empty() ? r.description : r.name, key);
+        std::string name = r.name.empty() ? r.description : r.name;
+        publishDiscovery(id, name, key);
+        publishTravelTimeDiscovery(id, name, key, r.travelTime);
         std::string t = "iown/" + id + "/set";
         mqttClient.subscribe(t.c_str(), 0);
         mqttClient.subscribe(("iown/" + id + "/pair").c_str(), 0);
         mqttClient.subscribe(("iown/" + id + "/add").c_str(), 0);
         mqttClient.subscribe(("iown/" + id + "/remove").c_str(), 0);
+        mqttClient.subscribe(("iown/" + id + "/travel_time/set").c_str(), 0);
         vTaskDelay(pdMS_TO_TICKS(200)); // throttle per device
     }
     if (!heartbeatTimer)
@@ -348,6 +388,26 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
             mqttClient.publish(topicStr.c_str(), 0, true, "", 0);
         } else {
             Serial.printf("*> MQTT Unknown device %s <*\n", id.c_str());
+        }
+        return;
+    }
+
+    if (topicStr.rfind("iown/", 0) == 0 && topicStr.find("/travel_time/set", 5) != std::string::npos) {
+        std::string id = topicStr.substr(5, topicStr.find("/travel_time/set", 5) - 5);
+        std::transform(id.begin(), id.end(), id.begin(), ::tolower);
+        const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
+        auto it = std::find_if(remotes.begin(), remotes.end(), [&](const auto &r) {
+            return bytesToHexString(r.node, sizeof(r.node)) == id;
+        });
+        if (it != remotes.end()) {
+            uint32_t tt = strtoul(payloadStr.c_str(), nullptr, 10);
+            if (tt > 0) {
+                IOHC::iohcRemote1W::getInstance()->setTravelTime(it->description, tt);
+                std::string stateTopic = "iown/" + id + "/travel_time";
+                std::string val = std::to_string(tt);
+                mqttClient.publish(stateTopic.c_str(), 0, true, val.c_str());
+            }
+            mqttClient.publish(topicStr.c_str(), 0, true, "", 0);
         }
         return;
     }


### PR DESCRIPTION
## Summary
- allow editing of blind travel time from Home Assistant via MQTT number entity
- handle travel_time MQTT messages and persist changes to config
- document travel time control

## Testing
- `pio run` *(failed: HTTPClientError while installing espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68989aca336083269b670e1383dbb130