### PR TITLE
Add blind position control via CLI and Home Assistant

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -27,6 +27,7 @@ VARIOUS 1W (Use the description name in 1W.json as argument)
 - **open**      _1W open device_
 - **close**     _1W close device_
 - **stop**      _1W stop device_
+- **position**  _1W set position (0-100)_
 - **vent**      _1W vent device_
 - **force**     _1W force device open_
 - **mode1**     _1W Mode1_

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ uploads or resets.
 Example payload for `B60D1A`:
 
 ```json
-{"name":"IZY1","command_topic":"iown/B60D1A/set","state_topic":"iown/B60D1A/state","position_topic":"iown/B60D1A/position","unique_id":"B60D1A","payload_open":"OPEN","payload_close":"CLOSE","payload_stop":"STOP","device_class":"blind","availability_topic":"iown/status"}
+{"name":"IZY1","command_topic":"iown/B60D1A/set","state_topic":"iown/B60D1A/state","position_topic":"iown/B60D1A/position","set_position_topic":"iown/B60D1A/position/set","unique_id":"B60D1A","payload_open":"OPEN","payload_close":"CLOSE","payload_stop":"STOP","device_class":"blind","availability_topic":"iown/status"}
 ```
 
 For each blind the firmware also publishes MQTT button entities that allow
@@ -134,8 +134,9 @@ Configure your MQTT broker settings in `include/user_config.h` (`mqtt_server`, `
 If you don't have an OLED display connected, comment out the `DISPLAY` definition in `include/user_config.h` to disable all display related code.
 
 Once discovery is complete you can control a blind by publishing `OPEN`, `CLOSE`
-or `STOP` to `iown/<id>/set`. The firmware listens on these topics and issues the
-corresponding command to the device.
+or `STOP` to `iown/<id>/set`, or a number between `0` and `100` to
+`iown/<id>/position/set` to move the blind to a specific position. The firmware
+listens on these topics and issues the corresponding command to the device.
 When an `OPEN` or `CLOSE` command is received, it immediately publishes the new
 state (`open` or `closed`) to `iown/<id>/state` so Home Assistant can update the
 cover status.

--- a/include/blind_position.h
+++ b/include/blind_position.h
@@ -18,6 +18,7 @@ namespace IOHC {
 
         float getPosition() const;
         bool isMoving() const;
+        void setPosition(float pos);
 
     private:
         enum class State { Idle, Opening, Closing };

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -41,6 +41,7 @@ namespace IOHC {
         Stop,
         Vent,
         ForceOpen,
+        Position,
         Mode1, Mode2, Mode3, Mode4
     };
 
@@ -60,6 +61,7 @@ namespace IOHC {
             enum class Movement { Idle, Opening, Closing } movement{Movement::Idle};
             float lastPublishedPosition{-1.0f};
             std::string lastPublishedState{};
+            float targetPosition{-1.0f};
         };
 
         static iohcRemote1W* getInstance();

--- a/src/blind_position.cpp
+++ b/src/blind_position.cpp
@@ -1,6 +1,7 @@
 #include <blind_position.h>
 #include <esp_timer.h>
 #include <Arduino.h>
+#include <algorithm>
 
 namespace IOHC {
     BlindPosition::BlindPosition(uint32_t travelTimeMs)
@@ -64,4 +65,9 @@ namespace IOHC {
     float BlindPosition::getPosition() const { return position; }
 
     bool BlindPosition::isMoving() const { return state != State::Idle; }
+
+    void BlindPosition::setPosition(float pos) {
+        position = std::clamp(pos, 0.0f, 100.0f);
+        lastUpdateUs = esp_timer_get_time();
+    }
 }

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -109,6 +109,9 @@ void createCommands() {
     Cmd::addHandler((char *) "stop", (char *) "1W stop device", [](Tokens *cmd)-> void {
         IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Stop, cmd);
     });
+    Cmd::addHandler((char *) "position", (char *) "1W set position 0-100", [](Tokens *cmd)-> void {
+        IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Position, cmd);
+    });
     Cmd::addHandler((char *) "vent", (char *) "1W vent device", [](Tokens *cmd)-> void {
         IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Vent, cmd);
     });

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -24,6 +24,7 @@
 #include <TickerUsESP32.h>
 #include <nvs_helpers.h>
 #include <cmath>
+#include <algorithm>
 #if defined(MQTT)
 #include <mqtt_handler.h>
 #endif
@@ -47,6 +48,7 @@ namespace IOHC {
             case RemoteButton::Stop: return "STOP";
             case RemoteButton::Vent: return "VENT";
             case RemoteButton::ForceOpen: return "FORCE";
+            case RemoteButton::Position: return "POSITION";
             case RemoteButton::Pair: return "PAIR";
             case RemoteButton::Add: return "ADD";
             case RemoteButton::Remove: return "REMOVE";
@@ -321,6 +323,7 @@ namespace IOHC {
                             packet->payload.packet.msg.p0x00_14.main[1] = 0x00;
                             r.positionTracker.startOpening();
                             r.movement = remote::Movement::Opening;
+                            r.targetPosition = 100.0f;
 #if defined(MQTT)
                             {
                                 std::string id = bytesToHexString(r.node, sizeof(r.node));
@@ -336,6 +339,7 @@ namespace IOHC {
                             packet->payload.packet.msg.p0x00_14.main[1] = 0x00;
                             r.positionTracker.startClosing();
                             r.movement = remote::Movement::Closing;
+                            r.targetPosition = 0.0f;
 #if defined(MQTT)
                             {
                                 std::string id = bytesToHexString(r.node, sizeof(r.node));
@@ -351,6 +355,7 @@ namespace IOHC {
                             packet->payload.packet.msg.p0x00_14.main[1] = 0x00;
                             r.positionTracker.stop();
                             r.movement = remote::Movement::Idle;
+                            r.targetPosition = r.positionTracker.getPosition();
 #if defined(MQTT)
                             {
                                 std::string id = bytesToHexString(r.node, sizeof(r.node));
@@ -369,6 +374,45 @@ namespace IOHC {
                             packet->payload.packet.msg.p0x00_14.main[0] = 0x64;
                             packet->payload.packet.msg.p0x00_14.main[1] = 0x00;
                             break;
+                        case RemoteButton::Position: {
+                            int index = (data->size() > 2) ? 2 : 0;
+                            int percent = atoi(data->at(index).c_str());
+                            percent = std::clamp(percent, 0, 100);
+                            uint8_t val = static_cast<uint8_t>((100 - percent) * 2);
+                            packet->payload.packet.msg.p0x00_14.main[0] = val;
+                            packet->payload.packet.msg.p0x00_14.main[1] = 0x00;
+                            float current = r.positionTracker.getPosition();
+                            if (percent > current + 0.5f) {
+                                r.positionTracker.startOpening();
+                                r.movement = remote::Movement::Opening;
+                                #if defined(MQTT)
+                                {
+                                    std::string id = bytesToHexString(r.node, sizeof(r.node));
+                                    publishCoverState(id, "OPENING");
+                                    publishCoverPosition(id, r.positionTracker.getPosition());
+                                    r.lastPublishedState = "OPENING";
+                                    r.lastPublishedPosition = r.positionTracker.getPosition();
+                                }
+                                #endif
+                            } else if (percent < current - 0.5f) {
+                                r.positionTracker.startClosing();
+                                r.movement = remote::Movement::Closing;
+                                #if defined(MQTT)
+                                {
+                                    std::string id = bytesToHexString(r.node, sizeof(r.node));
+                                    publishCoverState(id, "CLOSING");
+                                    publishCoverPosition(id, r.positionTracker.getPosition());
+                                    r.lastPublishedState = "CLOSING";
+                                    r.lastPublishedPosition = r.positionTracker.getPosition();
+                                }
+                                #endif
+                            } else {
+                                r.positionTracker.stop();
+                                r.movement = remote::Movement::Idle;
+                            }
+                            r.targetPosition = percent;
+                            break;
+                        }
                         case RemoteButton::Mode1:{
                             /* fast = 4x13 Increment fp2 - slow = 0x01 4x13 followed 0x00 4x14 Main 0xD2
                             Every 9 : 10:31:38.367 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  DATA(15)  02db000900000323e7ceefedf9ce81        SEQ 23e7 MAC ceefedf9ce81  Org 2 Acei DB Main 9 fp1 0 fp2 0  Acei 6 3 1 1  Type All
@@ -757,6 +801,7 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
             publishDiscovery(id, r.name, key);
             publishTravelTimeDiscovery(id, r.name, key, r.travelTime);
             mqttClient.subscribe(("iown/" + id + "/set").c_str(), 0);
+            mqttClient.subscribe(("iown/" + id + "/position/set").c_str(), 0);
             mqttClient.subscribe(("iown/" + id + "/pair").c_str(), 0);
             mqttClient.subscribe(("iown/" + id + "/add").c_str(), 0);
             mqttClient.subscribe(("iown/" + id + "/remove").c_str(), 0);
@@ -783,6 +828,7 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
         if (mqttClient.connected()) {
             removeDiscovery(id);
             mqttClient.unsubscribe(("iown/" + id + "/set").c_str());
+            mqttClient.unsubscribe(("iown/" + id + "/position/set").c_str());
             mqttClient.unsubscribe(("iown/" + id + "/pair").c_str());
             mqttClient.unsubscribe(("iown/" + id + "/add").c_str());
             mqttClient.unsubscribe(("iown/" + id + "/remove").c_str());
@@ -836,6 +882,23 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
 
             float pos = r.positionTracker.getPosition();
             bool moving = r.positionTracker.isMoving();
+
+            if (r.targetPosition >= 0.0f) {
+                if (r.movement == remote::Movement::Opening && pos >= r.targetPosition) {
+                    pos = r.targetPosition;
+                    r.positionTracker.setPosition(pos);
+                    r.positionTracker.stop();
+                    moving = false;
+                } else if (r.movement == remote::Movement::Closing && pos <= r.targetPosition) {
+                    pos = r.targetPosition;
+                    r.positionTracker.setPosition(pos);
+                    r.positionTracker.stop();
+                    moving = false;
+                }
+                if (!moving) {
+                    r.targetPosition = -1.0f;
+                }
+            }
 
             if (moving) {
                 Serial.printf("%s position: %.0f%%\n", r.name.c_str(), pos);


### PR DESCRIPTION
## Summary
- support setting blind position by percentage via new `position` command
- expose Home Assistant `set_position_topic` and handle MQTT position commands
- track target positions for accurate movement updates

## Testing
- `pio check` *(fails: HTTPClientError)*
- `pio run -e HeltecLoraV2ESP32 -t build` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_6898a88c8eb08326ae076733b56bb8a7