### PR TITLE
Expose device position in web API and UI

### DIFF
--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -177,7 +177,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             }
                         }
                     });
-                updateDeviceFill('b60d1a', 50);
+                updateDeviceFill(device.id, device.position || 0);
 
                 listItem.appendChild(upButton);
                 listItem.appendChild(stopButton);
@@ -315,6 +315,17 @@ document.addEventListener('DOMContentLoaded', function() {
         deviceEl.style.background = `linear-gradient(to bottom, ${color} ${percent}%, var(--color-input) ${percent}%)`;
     }
 
+    async function refreshDevicePositions() {
+        try {
+            const response = await fetch('/api/devices');
+            if (!response.ok) return;
+            const devices = await response.json();
+            devices.forEach(d => updateDeviceFill(d.id, d.position || 0));
+        } catch (e) {
+            console.error('Error refreshing positions', e);
+        }
+    }
+
     // popup open
     function openPopup(title, text, label, data, options = {}) {
         const labelInput = document.getElementById('label-input');
@@ -403,6 +414,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     setInterval(fetchLogs, 2000);
+    setInterval(refreshDevicePositions, 2000);
     fetchLogs();
     loadMqttConfig();
     // Initial fetch of devices

--- a/src/web_server_handler.cpp
+++ b/src/web_server_handler.cpp
@@ -37,6 +37,7 @@ void handleApiDevices(AsyncWebServerRequest *request) {
         JsonObject deviceObj = root.add<JsonObject>();
         deviceObj["id"] = bytesToHexString(r.node, sizeof(r.node)).c_str();
         deviceObj["name"] = r.name.c_str();
+        deviceObj["position"] = r.positionTracker.getPosition();
     }
 
     // Provide a generic command interface as last entry


### PR DESCRIPTION
## Summary
- Include current device position in `/api/devices` endpoint
- Update web UI to fill devices based on reported position
- Poll backend periodically to refresh on-screen positions

## Testing
- `platformio run` *(fails: HTTPClientError while installing `espressif32`)*

------
https://chatgpt.com/codex/tasks/task_e_689cba3a6dbc8326ad5e0ad427740597