### PR TITLE
Use absolute positioning for Home Assistant percent input

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ Configure your MQTT broker settings in `include/user_config.h` (`mqtt_server`, `
 If you don't have an OLED display connected, comment out the `DISPLAY` definition in `include/user_config.h` to disable all display related code.
 
 Once discovery is complete you can control a blind by publishing `OPEN`, `CLOSE`
-or `STOP` to `iown/<id>/set`, or a number between `0` and `100` to
+or `STOP` to `iown/<id>/set`, or a number between `0` (closed) and `100` (open) to
 `iown/<id>/position/set` to move the blind to a specific position. The firmware
-listens on these topics and issues the corresponding command to the device.
-`iown/<id>/absolute/set` accepts a value from 0 (fully open) to 100 (fully closed)
-and moves the blind using the protocol's absolute positioning.
+now uses the device's absolute positioning for these percentage commands, providing
+more accurate movement. For direct access to the raw absolute command where `0`
+means fully open and `100` fully closed, publish to `iown/<id>/absolute/set`.
 When an `OPEN` or `CLOSE` command is received, it immediately publishes the new
 state (`open` or `closed`) to `iown/<id>/state` so Home Assistant can update the
 cover status.


### PR DESCRIPTION
## Summary
- route Home Assistant percent commands through the device's absolute positioning for more accurate moves
- document the new absolute-driven behavior of `position/set`

## Testing
- `pio run` *(fails: HTTPClientError while installing espressif32)*

------
https://chatgpt.com/codex/tasks/task_e_689db2133fa48326bb6671e42e3f109c