### PR TITLE
Slow down discovery loops

### DIFF
--- a/src/iohcOtherDevice2W.cpp
+++ b/src/iohcOtherDevice2W.cpp
@@ -91,7 +91,7 @@ namespace IOHC {
                         discovery, packets2send.back()/*[j]*/->payload.buffer);
                     forgePacket(packets2send.back()/*[j]*//*->payload.buffer[4]*/, toSend, bec);
                     bec += 0x01;
-                    // packets2send.back()/*[j]*/->repeatTime = 225;
+                    packets2send.back()->repeatTime = 250; // Slow down discovery loop
                 }
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
@@ -288,6 +288,7 @@ namespace IOHC {
                     memcpy(packets2send.back()->payload.packet.header.source, /*from*/real/*gateway*/, 3);
 
                     packets2send.back()->delayed = 250; // Give enough time for the answer
+                    packets2send.back()->repeatTime = 250; // Slow down discover loop
                 }
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 


### PR DESCRIPTION
## Summary
- add 250ms repeat time to discovery loop
- add 250ms repeat time to discover2A loop

## Testing
- `pio run` (fails: HTTPClientError)


------
https://chatgpt.com/codex/tasks/task_e_689e0287bcac8326bad20bd19c25e00d