### PR TITLE
Ensure single network initialization after setup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,20 +123,9 @@ void setup() {
 #endif
     nvs_init();
 
-
-    // Initialize network services
-    initWifi();
-#if defined(MQTT)
-    initMqtt();
-#endif
-    // Load 1W device definitions before starting the web server so
+    // Load 1W device definitions before starting network services so
     // that /api/devices can immediately return the configured remotes.
     remote1W = IOHC::iohcRemote1W::getInstance();
-#if defined(WEBSERVER)
-    setupWebServer();
-#endif
-    Cmd::kbd_tick.attach_ms(500, Cmd::cmdFuncHandler);
-
 
     radioInstance = IOHC::iohcRadio::getInstance();
     radioInstance->start(MAX_FREQS, frequencies, 0, msgRcvd, publishMsg); //msgArchive); //, msgRcvd);


### PR DESCRIPTION
## Summary
- remove duplicate network service setup calls in `setup`
- start WiFi, MQTT and web server once after device initialization
- load remote definitions before starting network services

## Testing
- `pio run` *(fails: Platform Manager stuck installing espressif32)*

------
https://chatgpt.com/codex/tasks/task_e_689e31b94f688326ab7c98c6f3886ff7