### PR TITLE
Log device name in action log

### DIFF
--- a/src/web_server_handler.cpp
+++ b/src/web_server_handler.cpp
@@ -240,7 +240,7 @@ void handleApiAction(AsyncWebServerRequest *request, JsonVariant &json) {
   broadcastDevicePosition(deviceId,
                           static_cast<int>(it->positionTracker.getPosition()));
 
-  String msg = "Action " + action + " sent to " + deviceId;
+  String msg = "Action " + action + " sent to " + String(it->name.c_str());
   addLogMessage(msg);
 
   AsyncJsonResponse *response = new AsyncJsonResponse();


### PR DESCRIPTION
## Summary
- Show device name instead of numeric ID in action log entries

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e4904ef408326ab88fd88f3fbec2f