### PR TITLE
Add command for creating remote map entries

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -42,6 +42,7 @@ VARIOUS 1W (Use the description name in 1W.json as argument)
 - **list1W**   _List 1W devices_
 
 COMMON
+- **newRemote** _Create remote map entry_
 - **verbose**   _Toggle verbose output on packets list_
 - **help**      _This command_
 - **ls**        _List filesystem_

--- a/include/iohcRemoteMap.h
+++ b/include/iohcRemoteMap.h
@@ -21,10 +21,12 @@ namespace IOHC {
 
         const entry* find(const address node) const;
         bool load();
+        bool add(const address node, const std::string &name);
         const std::vector<entry>& getEntries() const;
 
     private:
         iohcRemoteMap();
+        bool save();
         static iohcRemoteMap* _instance;
         std::vector<entry> _entries;
     };

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -17,6 +17,7 @@
 #include <iohcRemote1W.h>
 #include <iohcCozyDevice2W.h>
 #include <iohcOtherDevice2W.h>
+#include <iohcRemoteMap.h>
 #include <interact.h>
 #include <wifi_helper.h>
 #include <oled_display.h>
@@ -171,6 +172,19 @@ void createCommands() {
                           r.travelTime,
                           r.paired ? "paired" : "unpaired");
         }
+    });
+    // Remote map
+    Cmd::addHandler((char *) "newRemote", (char *) "Create remote with address and name", [](Tokens *cmd)-> void {
+        if (cmd->size() < 3) {
+            Serial.println("Usage: newRemote <address> <name>");
+            return;
+        }
+        IOHC::address node{};
+        if (hexStringToBytes(cmd->at(1), node) != sizeof(IOHC::address)) {
+            Serial.println("Invalid address");
+            return;
+        }
+        IOHC::iohcRemoteMap::getInstance()->add(node, cmd->at(2));
     });
     // Other 2W
     Cmd::addHandler((char *) "discovery", (char *) "Send discovery on air", [](Tokens *cmd)-> void {


### PR DESCRIPTION
## Summary
- allow users to create remote entries via `newRemote` command
- support saving remote map entries with address and name
- document new command in command list

## Testing
- `pio run` *(fails: HTTPClientError)*
- `pio check` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a05b44e5f08326a8014b2caf81f624