### PR TITLE
feat: add remote device linking commands

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -43,6 +43,8 @@ VARIOUS 1W (Use the description name in 1W.json as argument)
 
 COMMON
 - **newRemote** _Create remote map entry_
+- **linkRemote** _Link device to remote map entry_
+- **unlinkRemote** _Remove device from remote map entry_
 - **verbose**   _Toggle verbose output on packets list_
 - **help**      _This command_
 - **ls**        _List filesystem_

--- a/include/iohcRemoteMap.h
+++ b/include/iohcRemoteMap.h
@@ -22,6 +22,8 @@ namespace IOHC {
         const entry* find(const address node) const;
         bool load();
         bool add(const address node, const std::string &name);
+        bool linkDevice(const address node, const std::string &device);
+        bool unlinkDevice(const address node, const std::string &device);
         const std::vector<entry>& getEntries() const;
 
     private:

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -186,6 +186,30 @@ void createCommands() {
         }
         IOHC::iohcRemoteMap::getInstance()->add(node, cmd->at(2));
     });
+    Cmd::addHandler((char *) "linkRemote", (char *) "Link device to remote", [](Tokens *cmd)-> void {
+        if (cmd->size() < 3) {
+            Serial.println("Usage: linkRemote <address> <device>");
+            return;
+        }
+        IOHC::address node{};
+        if (hexStringToBytes(cmd->at(1), node) != sizeof(IOHC::address)) {
+            Serial.println("Invalid address");
+            return;
+        }
+        IOHC::iohcRemoteMap::getInstance()->linkDevice(node, cmd->at(2));
+    });
+    Cmd::addHandler((char *) "unlinkRemote", (char *) "Remove device from remote", [](Tokens *cmd)-> void {
+        if (cmd->size() < 3) {
+            Serial.println("Usage: unlinkRemote <address> <device>");
+            return;
+        }
+        IOHC::address node{};
+        if (hexStringToBytes(cmd->at(1), node) != sizeof(IOHC::address)) {
+            Serial.println("Invalid address");
+            return;
+        }
+        IOHC::iohcRemoteMap::getInstance()->unlinkDevice(node, cmd->at(2));
+    });
     // Other 2W
     Cmd::addHandler((char *) "discovery", (char *) "Send discovery on air", [](Tokens *cmd)-> void {
         IOHC::iohcOtherDevice2W::getInstance()->cmd(IOHC::Other2WButton::discovery, nullptr);

--- a/src/iohcRemoteMap.cpp
+++ b/src/iohcRemoteMap.cpp
@@ -3,6 +3,7 @@
 #include <LittleFS.h>
 #include <iohcCryptoHelpers.h>
 #include <cstring>
+#include <algorithm>
 
 namespace IOHC {
     iohcRemoteMap* iohcRemoteMap::_instance = nullptr;
@@ -89,5 +90,36 @@ namespace IOHC {
         e.name = name;
         _entries.push_back(e);
         return save();
+    }
+
+    bool iohcRemoteMap::linkDevice(const address node, const std::string &device) {
+        for (auto &e : _entries) {
+            if (memcmp(e.node, node, sizeof(address)) == 0) {
+                if (std::find(e.devices.begin(), e.devices.end(), device) == e.devices.end()) {
+                    e.devices.push_back(device);
+                    return save();
+                }
+                Serial.println("Device already linked");
+                return false;
+            }
+        }
+        Serial.println("Remote not found");
+        return false;
+    }
+
+    bool iohcRemoteMap::unlinkDevice(const address node, const std::string &device) {
+        for (auto &e : _entries) {
+            if (memcmp(e.node, node, sizeof(address)) == 0) {
+                auto it = std::find(e.devices.begin(), e.devices.end(), device);
+                if (it != e.devices.end()) {
+                    e.devices.erase(it);
+                    return save();
+                }
+                Serial.println("Device not found");
+                return false;
+            }
+        }
+        Serial.println("Remote not found");
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- allow mapping devices to existing remotes via new link/unlink commands
- support persistence of device mappings in remote map storage

## Testing
- `pio run` *(fails: HTTPClientError while installing espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a0637a38c08326a2377c5016c05605