### PR TITLE
Add command to delete remote map entries

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -45,6 +45,7 @@ COMMON
 - **newRemote** _Create remote map entry_
 - **linkRemote** _Link device to remote map entry_
 - **unlinkRemote** _Remove device from remote map entry_
+- **delRemote** _Remove remote map entry_
 - **verbose**   _Toggle verbose output on packets list_
 - **help**      _This command_
 - **ls**        _List filesystem_

--- a/include/iohcRemoteMap.h
+++ b/include/iohcRemoteMap.h
@@ -24,6 +24,7 @@ namespace IOHC {
         bool add(const address node, const std::string &name);
         bool linkDevice(const address node, const std::string &device);
         bool unlinkDevice(const address node, const std::string &device);
+        bool remove(const address node);
         const std::vector<entry>& getEntries() const;
 
     private:

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -210,6 +210,18 @@ void createCommands() {
         }
         IOHC::iohcRemoteMap::getInstance()->unlinkDevice(node, cmd->at(2));
     });
+    Cmd::addHandler((char *) "delRemote", (char *) "Remove remote", [](Tokens *cmd)-> void {
+        if (cmd->size() < 2) {
+            Serial.println("Usage: delRemote <address>");
+            return;
+        }
+        IOHC::address node{};
+        if (hexStringToBytes(cmd->at(1), node) != sizeof(IOHC::address)) {
+            Serial.println("Invalid address");
+            return;
+        }
+        IOHC::iohcRemoteMap::getInstance()->remove(node);
+    });
     // Other 2W
     Cmd::addHandler((char *) "discovery", (char *) "Send discovery on air", [](Tokens *cmd)-> void {
         IOHC::iohcOtherDevice2W::getInstance()->cmd(IOHC::Other2WButton::discovery, nullptr);

--- a/src/iohcRemoteMap.cpp
+++ b/src/iohcRemoteMap.cpp
@@ -122,4 +122,15 @@ namespace IOHC {
         Serial.println("Remote not found");
         return false;
     }
+
+    bool iohcRemoteMap::remove(const address node) {
+        auto it = std::find_if(_entries.begin(), _entries.end(),
+                               [&](const entry &e) { return memcmp(e.node, node, sizeof(address)) == 0; });
+        if (it == _entries.end()) {
+            Serial.println("Remote not found");
+            return false;
+        }
+        _entries.erase(it);
+        return save();
+    }
 }


### PR DESCRIPTION
## Summary
- Allow removing a remote map entry via new `delRemote` CLI command
- Support remote removal with new `iohcRemoteMap::remove` method
- Document the new `delRemote` command

## Testing
- `pio run` *(fails: HTTPClientError while installing platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a065e723c883269ea21adc8ea589ed