### PR TITLE
Rename device popup buttons to link/unlink

### DIFF
--- a/extras/web_interface_data/index.html
+++ b/extras/web_interface_data/index.html
@@ -182,8 +182,8 @@
                     </select>  
                     <div class="popup-buttons">
                         <button id="popup-confirm" class="confirm">Confirm</button>
-                        <button id="popup-add" class="pair">ADD</button>
-                        <button id="popup-remove" class="pair">REMOVE</button>
+                        <button id="popup-add" class="pair">LINK</button>
+                        <button id="popup-remove" class="pair">UNLINK</button>
                         <button id="popup-delete" class="remove-device">delete</button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- rename device popup buttons from ADD/REMOVE to LINK/UNLINK

## Testing
- `pio run` *(fails: Platform Manager installing espressif32; process aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d97b37e88326811b4e67a232d570