### PR TITLE
feat: allow deleting remotes

### DIFF
--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -637,6 +637,24 @@ document.addEventListener('DOMContentLoaded', function() {
                     console.error('Error renaming remote:', error);
                     logStatus('Error renaming remote.', true);
                 }
+            },
+            onDelete: async () => {
+                try {
+                    const response = await fetch('/api/command', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ command: `delRemote ${remoteId}` })
+                    });
+                    const result = await response.json();
+                    if (result.success) {
+                        logStatus(result.message || 'Remote removed.');
+                    } else {
+                        logStatus(result.message || 'Failed to remove remote.', true);
+                    }
+                    fetchAndDisplayRemotes();
+                } catch (error) {
+                    logStatus(`Error removing remote: ${error.message}`, true);
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- allow deleting remote entries directly from the edit popup

## Testing
- `python -m platformio run` *(fails: Platform Manager installing espressif32)*

------
https://chatgpt.com/codex/tasks/task_e_68a9db671cb08326912f0dbac918fae8