### PR TITLE
fix: display linked devices on web interface

### DIFF
--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -154,9 +154,12 @@ document.addEventListener('DOMContentLoaded', function() {
             remotes.forEach(remote => {
                 const tr = document.createElement('tr');
 
-                // gekoppelde devices tonen, neem aan remote.devices is array
-                const linkedDevices = remote.devices && remote.devices.length > 0 
-                    ? remote.devices.map(d => d.name).join(', ')
+                // Show linked device names if available; fall back to raw id/name
+                const linkedDevices = (remote.devices && remote.devices.length > 0)
+                    ? remote.devices.map(d => {
+                        const dev = devicesCache.find(v => v.id === d || v.name === d);
+                        return dev ? dev.name : d;
+                    }).join(', ')
                     : '0 devices';
 
                 tr.innerHTML = `


### PR DESCRIPTION
## Summary
- Correctly resolve linked device names when rendering remotes so connected devices appear

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab199c5a6883268c107cbf7012d4fd