### PR TITLE
Allow names with spaces when adding devices and remotes

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -35,14 +35,14 @@ VARIOUS 1W (Use the description name in 1W.json as argument)
 - **mode2**     _1W Mode2_
 - **mode3**     _1W Mode3_
 - **mode4**     _1W Mode4_
-- **new1W**    _Add new 1W device_
+- **new1W**    _Add new 1W device (names may contain spaces)_
 - **del1W**    _Remove 1W device_
 - **edit1W**   _Edit 1W device name_
 - **time1W**   _Set 1W device travel time in seconds_
 - **list1W**   _List 1W devices_
 
 COMMON
-- **newRemote** _Create remote map entry_
+- **newRemote** _Create remote map entry (names may contain spaces)_
 - **linkRemote** _Link device to remote map entry_
 - **unlinkRemote** _Remove device from remote map entry_
 - **delRemote** _Remove remote map entry_

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -140,7 +140,11 @@ void createCommands() {
             Serial.println("Usage: new1W <name>");
             return;
         }
-        IOHC::iohcRemote1W::getInstance()->addRemote(cmd->at(1));
+        std::string name = cmd->at(1);
+        for (size_t i = 2; i < cmd->size(); ++i) {
+            name += " " + cmd->at(i);
+        }
+        IOHC::iohcRemote1W::getInstance()->addRemote(name);
     });
     Cmd::addHandler((char *) "del1W", (char *) "Remove 1W device", [](Tokens *cmd)-> void {
         if (cmd->size() < 2) {
@@ -154,7 +158,11 @@ void createCommands() {
             Serial.println("Usage: edit1W <description> <name>");
             return;
         }
-        IOHC::iohcRemote1W::getInstance()->renameRemote(cmd->at(1), cmd->at(2));
+        std::string name = cmd->at(2);
+        for (size_t i = 3; i < cmd->size(); ++i) {
+            name += " " + cmd->at(i);
+        }
+        IOHC::iohcRemote1W::getInstance()->renameRemote(cmd->at(1), name);
     });
     Cmd::addHandler((char *) "time1W", (char *) "Set 1W device travel time", [](Tokens *cmd)-> void {
         if (cmd->size() < 3) {
@@ -185,7 +193,11 @@ void createCommands() {
             Serial.println("Invalid address");
             return;
         }
-        IOHC::iohcRemoteMap::getInstance()->add(node, cmd->at(2));
+        std::string name = cmd->at(2);
+        for (size_t i = 3; i < cmd->size(); ++i) {
+            name += " " + cmd->at(i);
+        }
+        IOHC::iohcRemoteMap::getInstance()->add(node, name);
     });
     Cmd::addHandler((char *) "linkRemote", (char *) "Link device to remote", [](Tokens *cmd)-> void {
         if (cmd->size() < 3) {


### PR DESCRIPTION
## Summary
- Support multi-word names when adding 1W devices and remote map entries
- Document that new1W and newRemote commands accept names with spaces

## Testing
- `pio check` *(fails: toolchain download stalled)*
- `pio run -t clean` *(fails: platform install stalled)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1941e0b8832683cc552df0049520