### PR TITLE
Show device names in remote list

### DIFF
--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -157,7 +157,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 // Show linked device names if available; fall back to raw id/name
                 const linkedDevices = (remote.devices && remote.devices.length > 0)
                     ? remote.devices.map(d => {
-                        const dev = devicesCache.find(v => v.id === d || v.name === d);
+                        const dev = devicesCache.find(v => v.id === d || v.name === d || v.description === d);
                         return dev ? dev.name : d;
                     }).join(', ')
                     : '0 devices';

--- a/src/web_server_handler.cpp
+++ b/src/web_server_handler.cpp
@@ -110,6 +110,7 @@ void handleApiDevices(AsyncWebServerRequest *request) {
     JsonObject deviceObj = root.add<JsonObject>();
     deviceObj["id"] = bytesToHexString(r.node, sizeof(r.node)).c_str();
     deviceObj["name"] = r.name.c_str();
+    deviceObj["description"] = r.description.c_str();
     deviceObj["position"] = r.positionTracker.getPosition();
     deviceObj["travel_time"] = r.travelTime;
   }


### PR DESCRIPTION
## Summary
- Add device description to `/api/devices` endpoint so remotes can be matched to their names
- Update web UI to resolve remote devices by ID, name or description and display the device name

## Testing
- `npm test` *(fails: package.json not found)*
- `platformio run` *(fails: HTTPClientError during platform install)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2255dacc8326ace86872cce45bbf