### PR TITLE
Reorganise edit device popup UI

### DIFF
--- a/extras/web_interface_data/index.html
+++ b/extras/web_interface_data/index.html
@@ -172,24 +172,30 @@
             </div>
             <div class="card-popup">
                 <div id="left">
-                    <label for="popup-input" id="label-input">device:</label>
-                    <input type="text" id="popup-input" placeholder="Typ hier..." autocomplete="off">
-                    <label for="popup-input-timing" id="label-timing">timing:</label>
-                    <input type="text" id="popup-input-timing" placeholder="Typ hier..." autocomplete="off">
-                    <label for="popup-device-select" class="device-popup-label">device:</label>
-                    <select id="popup-device-select" class="device-popup">
-                        
-                    </select>  
-                    <div class="popup-buttons">
+                    <div class="edit-group">
+                        <label for="popup-input" id="label-input">device:</label>
+                        <input type="text" id="popup-input" placeholder="Typ hier..." autocomplete="off">
+                        <label for="popup-input-timing" id="label-timing">timing:</label>
+                        <input type="text" id="popup-input-timing" placeholder="Typ hier..." autocomplete="off">
+                        <label for="popup-device-select" class="device-popup-label">device:</label>
+                        <select id="popup-device-select" class="device-popup">
+
+                        </select>
                         <button id="popup-confirm" class="confirm">Confirm</button>
-                        <button id="popup-add" class="pair">LINK</button>
-                        <button id="popup-remove" class="pair">UNLINK</button>
-                        <button id="popup-delete" class="remove-device">delete</button>
+                    </div>
+                    <p id="pair-label">Add / Remove the device to the physical screen</p>
+                    <div class="popup-buttons">
+                        <button id="popup-add" class="pair">Add</button>
+                        <button id="popup-remove" class="pair">Remove</button>
+                    </div>
+                    <div class="delete-block">
+                        <button id="popup-delete" class="remove-device">Delete</button>
+                        <p id="delete-info">Only use when the device is not linked to a physical screen.</p>
                     </div>
                 </div>
                 <div id="right">
                     <p id="popup-content">Tekst komt hier.</p>
-                </div>                
+                </div>
             </div>
         </div>
     </div>

--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -249,12 +249,16 @@ document.addEventListener('DOMContentLoaded', function() {
                     openPopup('Edit Device', "Adjust the name:",
                         [
                             'ID: ' + device.id,
-                            'Status: ' + device.position,
+                            'Description: ' + (device.description || ''),
+                            'Position: ' + device.position + '%',
+                            'Paired: ' + (device.paired ? 'Yes' : 'No'),
                         ], {
                         showInput: true,
                         showTiming: true,
                         defaultValue: device.name,
                         defaultTiming: device.travel_time,
+                        pairLabel: 'Add / Remove the device to the physical screen',
+                        deleteInfo: 'Only use when the device is not linked to a physical screen.',
                         onConfirm: async (newName, newTiming) => {
                             try {
                                 if (newName.trim() && newName !== device.name) {
@@ -482,6 +486,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const deleteBtn = document.getElementById('popup-delete');
         const devicePopupLabel = document.querySelector('.device-popup-label');
         const devicePopup = document.querySelector('.device-popup');
+        const pairLabelEl = document.getElementById('pair-label');
+        const deleteInfo = document.getElementById('delete-info');
         document.getElementById('popup-title').textContent = title;
         labelInput.textContent = label;
 
@@ -515,8 +521,15 @@ document.addEventListener('DOMContentLoaded', function() {
         // items is een array van strings
         const content = items.map(i => `<p>${i}</p>`).join('');
         document.getElementById('popup-content').innerHTML = content;
-        const addLabel = options.addLabel || 'ADD';
-        const removeLabel = options.removeLabel || 'REMOVE';
+        const addLabel = options.addLabel || 'Add';
+        const removeLabel = options.removeLabel || 'Remove';
+
+        if (options && options.pairLabel && (options.onAdd || options.onRemove)) {
+            pairLabelEl.style.display = 'block';
+            pairLabelEl.textContent = options.pairLabel;
+        } else {
+            pairLabelEl.style.display = 'none';
+        }
 
         if (options && options.onAdd) {
             addBtn.style.display = 'block';
@@ -546,6 +559,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
         if (options && options.onDelete) {
             deleteBtn.style.display = 'block';
+            deleteInfo.style.display = options.deleteInfo ? 'block' : 'none';
+            if (options.deleteInfo) deleteInfo.textContent = options.deleteInfo;
             deleteBtn.onclick = () => {
                 closePopup();
                 options.onDelete();
@@ -553,6 +568,7 @@ document.addEventListener('DOMContentLoaded', function() {
         } else {
             deleteBtn.style.display = 'none';
             deleteBtn.onclick = null;
+            deleteInfo.style.display = 'none';
         }
 
         // OK button

--- a/extras/web_interface_data/style.css
+++ b/extras/web_interface_data/style.css
@@ -261,8 +261,31 @@ footer {
 #popup-text {
   padding-bottom: 15px;
 }
+.edit-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#pair-label {
+  margin-top: 12px;
+}
+
 .popup-buttons {
   display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.delete-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 12px;
+}
+
+#delete-info {
+  font-size: 12px;
 }
 #popup.open {
   display: flex;


### PR DESCRIPTION
## Summary
- Display device ID, description, position and pairing status in edit popup
- Group name and timing edits with confirm action and add guidance
- Style popup with labeled add/remove and delete warning

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab23babc288326a0045ef5b9f34ece