### PR TITLE
Ensure initial device positions show on web interface

### DIFF
--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -349,7 +349,6 @@ document.addEventListener('DOMContentLoaded', function() {
                             }
                         }
                     });
-                updateDeviceFill(device.id, device.position || 0);
 
                 listItem.appendChild(upButton);
                 listItem.appendChild(stopButton);
@@ -357,6 +356,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 listItem.appendChild(editButton);
                 // TODO: Add buttons for simple actions if desired in future
                 deviceListUL.appendChild(listItem);
+
+                // Apply initial position now that the element exists in the DOM
+                updateDeviceFill(device.id, device.position || 0);
 
                 // Populate the SELECT for command sending
                 const option = document.createElement('option');


### PR DESCRIPTION
## Summary
- update web interface logic to apply device fill after DOM insertion so positions show immediately on load

## Testing
- `pio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68ab293d2a308326a15bfe8a04a326f7