### PR TITLE
Process remote inputs through internal state machine

### DIFF
--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -69,6 +69,7 @@ namespace IOHC {
         ~iohcRemote1W() override = default;
 
         void cmd(RemoteButton cmd, Tokens* data);
+        void handleRemoteAction(RemoteButton cmd, const std::string &description);
         bool load() override;
         bool save() override;
 //        void scanDump() override { }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "log_buffer.h"
 #include <stdarg.h>
 #include <algorithm>
+#include <cstring>
 
 #if defined(WEBSERVER)
 #include <web_server_handler.h>
@@ -477,18 +478,15 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
                 display1WAction(iohc->payload.packet.header.source, action, "RX");
                 #endif
                 if (const auto *map = remoteMap->find(iohc->payload.packet.header.source)) {
-                    const auto &remotes = iohcRemote1W::getInstance()->getRemotes();
+                    IOHC::RemoteButton btn;
+                    if (!strcmp(action, "OPEN")) btn = IOHC::RemoteButton::Open;
+                    else if (!strcmp(action, "CLOSE")) btn = IOHC::RemoteButton::Close;
+                    else if (!strcmp(action, "STOP")) btn = IOHC::RemoteButton::Stop;
+                    else if (!strcmp(action, "VENT")) btn = IOHC::RemoteButton::Vent;
+                    else if (!strcmp(action, "FORCE")) btn = IOHC::RemoteButton::ForceOpen;
+                    else btn = IOHC::RemoteButton::Stop; // default to avoid uninitialized
                     for (const auto &desc : map->devices) {
-                        auto rit = std::find_if(remotes.begin(), remotes.end(), [&](const auto &r){
-                            return r.description == desc;
-                        });
-                        if (rit != remotes.end()) {
-                            std::string id = bytesToHexString(rit->node, sizeof(rit->node));
-#if defined(MQTT)
-                            std::string topic = "iown/" + id + "/state";
-                            mqttClient.publish(topic.c_str(), 0, false, action);
-#endif
-                        }
+                        iohcRemote1W::getInstance()->handleRemoteAction(btn, desc);
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary
- Feed mapped remote commands into iohcRemote1W's state machine
- Add `handleRemoteAction` to update position tracker and publish MQTT state without radio transmission
- Wire remote packet handling in `msgRcvd` to invoke new local action handler

## Testing
- `pio check` *(fails: HTTPClientError)*


------
https://chatgpt.com/codex/tasks/task_e_68ab2a00031c83269b13a8efd4b367a4