### PR TITLE
Add download buttons for configuration files

### DIFF
--- a/extras/web_interface_data/index.html
+++ b/extras/web_interface_data/index.html
@@ -119,6 +119,10 @@
                         <label for="filesystem-file">Filesystem:</label>
                         <div class="filesystem-line"><input type="file" id="filesystem-file" accept=".bin">
                         <button id="upload-filesystem">Upload Filesystem</button></div>
+                        <label>Download:</label>
+                        <div class="download-line">
+                        <button id="download-devices">Download Devices</button>
+                        <button id="download-remotes">Download Remotes</button></div>
                     </div>
                 </section>
             </div>

--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -16,6 +16,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const filesystemFileInput = document.getElementById('filesystem-file');
     const firmwareUploadButton = document.getElementById('upload-firmware');
     const filesystemUploadButton = document.getElementById('upload-filesystem');
+    const downloadDevicesButton = document.getElementById('download-devices');
+    const downloadRemotesButton = document.getElementById('download-remotes');
     const lastAddrInput = document.getElementById('last-address');
     const ws = new WebSocket(`ws://${window.location.host}/ws`);
 
@@ -133,6 +135,25 @@ document.addEventListener('DOMContentLoaded', function() {
             console.error('Error uploading filesystem', e);
             logStatus('Error uploading filesystem', true);
         }
+    }
+
+    function downloadFile(url, filename) {
+        fetch(url)
+            .then(resp => {
+                if (!resp.ok) throw new Error('Network response was not ok');
+                return resp.blob();
+            })
+            .then(blob => {
+                const link = document.createElement('a');
+                link.href = window.URL.createObjectURL(blob);
+                link.download = filename;
+                link.click();
+                window.URL.revokeObjectURL(link.href);
+            })
+            .catch(err => {
+                console.error('Error downloading file', err);
+                logStatus('Error downloading file', true);
+            });
     }
    
     async function fetchAndDisplayRemotes() {
@@ -424,6 +445,12 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     if (filesystemUploadButton) {
         filesystemUploadButton.addEventListener('click', uploadFilesystem);
+    }
+    if (downloadDevicesButton) {
+        downloadDevicesButton.addEventListener('click', () => downloadFile('/api/download/devices', '1W.json'));
+    }
+    if (downloadRemotesButton) {
+        downloadRemotesButton.addEventListener('click', () => downloadFile('/api/download/remotes', 'RemoteMap.json'));
     }
 
     // suggestions for command input

--- a/src/web_server_handler.cpp
+++ b/src/web_server_handler.cpp
@@ -148,6 +148,24 @@ void handleApiRemotes(AsyncWebServerRequest *request) {
   request->send(response);
 }
 
+void handleDownloadDevices(AsyncWebServerRequest *request) {
+  if (LittleFS.exists(IOHC_1W_REMOTE)) {
+    request->send(LittleFS, IOHC_1W_REMOTE, "application/json", true);
+  } else {
+    request->send(404, "application/json",
+                  "{\"message\":\"1W.json not found\"}");
+  }
+}
+
+void handleDownloadRemotes(AsyncWebServerRequest *request) {
+  if (LittleFS.exists(REMOTE_MAP_FILE)) {
+    request->send(LittleFS, REMOTE_MAP_FILE, "application/json", true);
+  } else {
+    request->send(404, "application/json",
+                  "{\"message\":\"RemoteMap.json not found\"}");
+  }
+}
+
 void handleApiCommand(AsyncWebServerRequest *request, JsonVariant &json) {
   if (request->method() != HTTP_POST) {
     request->send(405, "text/plain", "Method Not Allowed");
@@ -504,6 +522,8 @@ void setupWebServer() {
             handleFirmwareUpload);
   server.on("/api/filesystem", HTTP_POST, handleFilesystemUpdate,
             handleFilesystemUpload);
+  server.on("/api/download/devices", HTTP_GET, handleDownloadDevices);
+  server.on("/api/download/remotes", HTTP_GET, handleDownloadRemotes);
 
   ws.onEvent(onWsEvent);
   server.addHandler(&ws);


### PR DESCRIPTION
## Summary
- Add device and remote map download buttons to settings update section
- Implement client-side download logic for device and remote map files
- Serve 1W.json and RemoteMap.json via new web server endpoints

## Testing
- `pio run` *(fails: HTTPClientError while installing espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ab516692688326a81e45d92da9c22c