### PR TITLE
Add upload support for device and remote configuration files

### DIFF
--- a/extras/web_interface_data/index.html
+++ b/extras/web_interface_data/index.html
@@ -119,9 +119,13 @@
                         <label for="filesystem-file">Filesystem:</label>
                         <div class="filesystem-line"><input type="file" id="filesystem-file" accept=".bin">
                         <button id="upload-filesystem">Upload Filesystem</button></div>
-                        <label>Download:</label>
-                        <div class="download-line">
-                        <button id="download-devices">Download Devices</button>
+                        <label for="devices-file">Devices:</label>
+                        <div class="devices-line"><input type="file" id="devices-file" accept=".json">
+                        <button id="upload-devices">Upload Devices</button>
+                        <button id="download-devices">Download Devices</button></div>
+                        <label for="remotes-file">Remotes:</label>
+                        <div class="remotes-line"><input type="file" id="remotes-file" accept=".json">
+                        <button id="upload-remotes">Upload Remotes</button>
                         <button id="download-remotes">Download Remotes</button></div>
                     </div>
                 </section>

--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -16,6 +16,10 @@ document.addEventListener('DOMContentLoaded', function() {
     const filesystemFileInput = document.getElementById('filesystem-file');
     const firmwareUploadButton = document.getElementById('upload-firmware');
     const filesystemUploadButton = document.getElementById('upload-filesystem');
+    const devicesFileInput = document.getElementById('devices-file');
+    const remotesFileInput = document.getElementById('remotes-file');
+    const devicesUploadButton = document.getElementById('upload-devices');
+    const remotesUploadButton = document.getElementById('upload-remotes');
     const downloadDevicesButton = document.getElementById('download-devices');
     const downloadRemotesButton = document.getElementById('download-remotes');
     const lastAddrInput = document.getElementById('last-address');
@@ -134,6 +138,45 @@ document.addEventListener('DOMContentLoaded', function() {
         } catch (e) {
             console.error('Error uploading filesystem', e);
             logStatus('Error uploading filesystem', true);
+        }
+    }
+
+    async function uploadDevices() {
+        const file = devicesFileInput.files[0];
+        if (!file) {
+            logStatus('No devices file selected', true);
+            return;
+        }
+        const formData = new FormData();
+        formData.append('file', file);
+        try {
+            const resp = await fetch('/api/upload/devices', { method: 'POST', body: formData });
+            const result = await resp.json();
+            logStatus(result.message || 'Devices file uploaded');
+            fetchAndDisplayDevices();
+            fetchAndDisplayRemotes();
+        } catch (e) {
+            console.error('Error uploading devices file', e);
+            logStatus('Error uploading devices file', true);
+        }
+    }
+
+    async function uploadRemotes() {
+        const file = remotesFileInput.files[0];
+        if (!file) {
+            logStatus('No remotes file selected', true);
+            return;
+        }
+        const formData = new FormData();
+        formData.append('file', file);
+        try {
+            const resp = await fetch('/api/upload/remotes', { method: 'POST', body: formData });
+            const result = await resp.json();
+            logStatus(result.message || 'Remotes file uploaded');
+            fetchAndDisplayRemotes();
+        } catch (e) {
+            console.error('Error uploading remotes file', e);
+            logStatus('Error uploading remotes file', true);
         }
     }
 
@@ -445,6 +488,12 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     if (filesystemUploadButton) {
         filesystemUploadButton.addEventListener('click', uploadFilesystem);
+    }
+    if (devicesUploadButton) {
+        devicesUploadButton.addEventListener('click', uploadDevices);
+    }
+    if (remotesUploadButton) {
+        remotesUploadButton.addEventListener('click', uploadRemotes);
     }
     if (downloadDevicesButton) {
         downloadDevicesButton.addEventListener('click', () => downloadFile('/api/download/devices', '1W.json'));

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -655,6 +655,7 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
 
    bool iohcRemote1W::load() {
         _radioInstance = iohcRadio::getInstance();
+        remotes.clear();
 
         if (LittleFS.exists(IOHC_1W_REMOTE))
             Serial.printf("Loading 1W remote settings from %s\n", IOHC_1W_REMOTE);


### PR DESCRIPTION
## Summary
- allow reloading of devices by clearing in-memory list before loading
- add API endpoints for uploading devices and remotes JSON files and register them with the web server
- expose file inputs and upload/download controls for devices and remotes in the web UI
- handle device and remote uploads on the client and refresh lists after upload

## Testing
- `pio test` *(fails: A test folder '/workspace/iohomecontrol/test' does not exist)*
- `pio run` *(fails: HTTPClientError while installing espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5eba7cf08326b208b15568eb781b