### PR TITLE
Add remote syslog support

### DIFF
--- a/include/syslog_helper.h
+++ b/include/syslog_helper.h
@@ -1,0 +1,14 @@
+/*
+   Syslog helper for forwarding log messages to a remote server
+*/
+
+#ifndef SYSLOG_HELPER_H
+#define SYSLOG_HELPER_H
+
+#include <Arduino.h>
+
+void initSyslog();
+void sendSyslog(const String &msg);
+
+#endif // SYSLOG_HELPER_H
+

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -35,6 +35,10 @@ inline std::string mqtt_user = "mosquitto";
 inline std::string mqtt_password = "";
 inline std::string mqtt_discovery_topic = "homeassistant";
 
+#define SYSLOG                       // Comment out to disable remote syslog
+inline std::string syslog_server = ""; // Syslog server IP address
+inline uint16_t syslog_port = 514;     // Syslog server port
+
 // Comment out the next line if no display is connected
 #define SSD1306_DISPLAY
 

--- a/src/log_buffer.cpp
+++ b/src/log_buffer.cpp
@@ -5,6 +5,9 @@
 #if defined(WEBSERVER)
 #include <web_server_handler.h>
 #endif
+#if defined(SYSLOG)
+#include <syslog_helper.h>
+#endif
 
 namespace {
     std::deque<String> logDeque;
@@ -18,6 +21,9 @@ void addLogMessage(const String &msg) {
     logDeque.push_back(msg);
 #if defined(WEBSERVER)
     broadcastLog(msg);
+#endif
+#if defined(SYSLOG)
+    sendSyslog(msg);
 #endif
 }
 

--- a/src/syslog_helper.cpp
+++ b/src/syslog_helper.cpp
@@ -1,0 +1,41 @@
+#include <syslog_helper.h>
+
+#if defined(SYSLOG)
+
+#include <WiFiUdp.h>
+#include <user_config.h>
+
+namespace {
+    WiFiUDP syslogUdp;
+    IPAddress syslogIP;
+    bool syslogReady = false;
+}
+
+void initSyslog() {
+    if (syslogReady) {
+        return;
+    }
+    if (syslog_server.empty()) {
+        return;
+    }
+    if (!syslogIP.fromString(syslog_server.c_str())) {
+        return;
+    }
+    syslogUdp.begin(0);
+    syslogReady = true;
+}
+
+void sendSyslog(const String &msg) {
+    if (!syslogReady) {
+        initSyslog();
+    }
+    if (!syslogReady) {
+        return;
+    }
+    syslogUdp.beginPacket(syslogIP, syslog_port);
+    syslogUdp.write(msg.c_str());
+    syslogUdp.endPacket();
+}
+
+#endif // SYSLOG
+


### PR DESCRIPTION
## Summary
- add configurable SYSLOG settings and server IP in user config
- forward queued log entries to remote syslog
- implement UDP-based syslog helper

## Testing
- `python3 -m platformio check` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68b21a6e1f9c8326a0d36fc876822bec