### PR TITLE
Restore periodic ticker for radio hopping

### DIFF
--- a/include/iohcRadio.h
+++ b/include/iohcRadio.h
@@ -98,6 +98,7 @@ namespace IOHC {
             static void lightTxTask(void *pvParameters);
             //TaskHandle_t txTaskHandle = nullptr;
             static void IRAM_ATTR onTxTicker(void *arg);
+            static void IRAM_ATTR onScanTicker(void *arg);
 
             uint8_t num_freqs = 0;
             uint32_t *scan_freqs{};

--- a/src/iohcOther2W.cpp
+++ b/src/iohcOther2W.cpp
@@ -325,7 +325,7 @@ namespace IOHC {
                     packets2send.back()->repeat = 4;
                     packets2send.back()->repeatTime = 60;
                     // packets2send.back()->delayed = 75; // Give enough time for the answer
-                    // packets2send.back()->frequency = CHANNEL3;
+                    // packets2send.back()->frequency = CHANNEL1;
                 }
 
                 _radioInstance->send(packets2send);

--- a/src/iohcPacket.cpp
+++ b/src/iohcPacket.cpp
@@ -31,7 +31,6 @@
 namespace IOHC {
 
     void IRAM_ATTR iohcPacket::decode(bool verbosity) {
-
         bool save2W =  false;
 
         if (packetStamp - relStamp > 500000L) {
@@ -72,11 +71,11 @@ namespace IOHC {
                this->payload.packet.header.target[2],
                this->payload.packet.header.cmd);
         
-        // if (verbosity) printf(" +%03.3f F%03.3f, %03.1fdBm %f %f\t", static_cast<float>(packetStamp - relStamp)/1000.0, static_cast<float>(this->frequency)/1000000.0, this->rssi, this->lna, this->afc);
+        if (verbosity) printf(" +%03.3f F%03.3f, %03.1fdBm %f %f\t", static_cast<float>(packetStamp - relStamp)/1000.0, static_cast<float>(this->frequency)/1000000.0, this->rssi, this->lna, this->afc);
         // if (verbosity) printf(" +%03.3f F%03.3f, %03.1fdBm %f\t", static_cast<float>(packetStamp - relStamp)/1000.0, static_cast<float>(this->frequency)/1000000.0, this->rssi, this->afc);
         // if (verbosity) printf(" +%03.3f\t%03.1fdBm\t", static_cast<float>(packetStamp - relStamp)/1000.0,  this->rssi);
-        //if (verbosity) printf(" +%03.3f F%03.3f\t", static_cast<float>(packetStamp - relStamp)/1000.0, static_cast<float>(this->frequency)/1000000.0);
-        if (verbosity) ets_printf(" +%03d\t", static_cast<int>((packetStamp - relStamp)/1000.0));
+        // if (verbosity) printf(" +%03.3f F%03.3f\t", static_cast<float>(packetStamp - relStamp)/1000.0, static_cast<float>(this->frequency)/1000000.0);
+        //if (verbosity) ets_printf(" +%03d\t", static_cast<int>((packetStamp - relStamp)/1000.0));
         ets_printf(" %s ", _dir);
 
         uint8_t dataLen = this->buffer_length - 9;

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -76,9 +76,9 @@ namespace IOHC {
     void IRAM_ATTR handle_interrupt_fromisr(/*void *arg*/) {
         iohcRadio::_g_preamble = digitalRead(RADIO_PREAMBLE_DETECTED);
         iohcRadio::f_lock_hop = iohcRadio::_g_preamble;
-iohcRadio::setRadioState(iohcRadio::_g_preamble ? iohcRadio::RadioState::PREAMBLE : iohcRadio::RadioState::RX);
+        iohcRadio::setRadioState(iohcRadio::_g_preamble ? iohcRadio::RadioState::PREAMBLE : iohcRadio::RadioState::RX);
         iohcRadio::_g_payload = digitalRead(RADIO_PACKET_AVAIL);
-iohcRadio::setRadioState(iohcRadio::_g_payload ? iohcRadio::RadioState::PAYLOAD : iohcRadio::RadioState::RX);
+        iohcRadio::setRadioState(iohcRadio::_g_payload ? iohcRadio::RadioState::PAYLOAD : iohcRadio::RadioState::RX);
         iohcRadio::txComplete = true;
         // Notify the thread so it will wake up when the ISR is complete
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
@@ -164,12 +164,12 @@ iohcRadio::setRadioState(iohcRadio::_g_payload ? iohcRadio::RadioState::PAYLOAD 
         // Radio::calibrate();
         Radio::setRx();
 
-#if defined(ESP32)
-        if (TickTimer.active()) {
-            TickTimer.detach();
-        }
-        TickTimer.attach_us(SM_GRANULARITY_US, tickerCounter, this);
-#endif
+//#if defined(ESP32)
+//        if (TickTimer.active()) {
+//            TickTimer.detach();
+//        }
+//        TickTimer.attach_us(SM_GRANULARITY_US, tickerCounter, this);
+//#endif
     }
 
 /**
@@ -295,7 +295,7 @@ iohcRadio::setRadioState(iohcRadio::_g_payload ? iohcRadio::RadioState::PAYLOAD 
 
         Radio::setStandby();
         Radio::clearFlags();
-Radio::setPreambleLength(LONG_PREAMBLE_MS);
+        Radio::setPreambleLength(LONG_PREAMBLE_MS);
         Radio::writeBytes(REG_FIFO, radio->iohc->payload.buffer, radio->iohc->buffer_length);
         Radio::setTx();
         radio->setRadioState(iohcRadio::RadioState::TX);
@@ -314,7 +314,7 @@ Radio::setPreambleLength(LONG_PREAMBLE_MS);
         if (radio->iohc->repeat) {
             // Only the first frame is LPM (1W)
             radio->iohc->payload.packet.header.CtrlByte2.asStruct.LPM = 0;
-Radio::setPreambleLength(SHORT_PREAMBLE_MS);
+            Radio::setPreambleLength(SHORT_PREAMBLE_MS);
 
             radio->iohc->repeat -= 1;
         }
@@ -372,7 +372,7 @@ Radio::setPreambleLength(SHORT_PREAMBLE_MS);
  * 
  * @return The function `iohcRadio::receive` is returning a boolean value `true`.
  */
-    bool IRAM_ATTR iohcRadio::receive(bool stats = false) {
+    bool IRAM_ATTR iohcRadio::receive(bool stats = true) {
         digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 
         // Create a new packet for this reception. Use a pointer to pass to the callback.
@@ -401,18 +401,19 @@ Radio::setPreambleLength(SHORT_PREAMBLE_MS);
                 Radio::readByte(REG_FIFO);
             }
         }
-
-        if (/*bool is_duplicate = last1wPacketValid &&*/ *currentPacket == last1wPacket) {
+        
+        //if (/*bool is_duplicate = last1wPacketValid &&*/ *currentPacket == last1wPacket) {
             // ets_printf("Same packet, skipping\n");
-        } else {
-            if (rxCB) rxCB(currentPacket);
+        //} else {
+        //    if (rxCB) rxCB(currentPacket);
             currentPacket->decode(true); //stats);
             // addLogMessage(String(currentPacket->decodeToString(true).c_str()));
 
             // Save the new packet's data for the next comparison
-            last1wPacket = *currentPacket;
+        //    last1wPacket = *currentPacket;
             /*last1wPacketValid = true;*/
-        }
+        //}
+        
 
         delete currentPacket; // The packet is processed or duplicated, we can free it.
 

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -163,6 +163,13 @@ iohcRadio::setRadioState(iohcRadio::_g_payload ? iohcRadio::RadioState::PAYLOAD 
         Radio::setCarrier(Radio::Carrier::Frequency, CHANNEL2); // scan_freqs[0]); //868950000);
         // Radio::calibrate();
         Radio::setRx();
+
+#if defined(ESP32)
+        if (TickTimer.active()) {
+            TickTimer.detach();
+        }
+        TickTimer.attach_us(SM_GRANULARITY_US, tickerCounter, this);
+#endif
     }
 
 /**

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -58,9 +58,13 @@ namespace IOHC {
         constexpr TickType_t xMaxBlockTime = pdMS_TO_TICKS(655 * 4); // 218.4 );
         while (true) {
             thread_notification = ulTaskNotifyTake(pdTRUE, xMaxBlockTime/*xNoDelay*/); // Attendre la notification
-            while (thread_notification > 0) {
+            if (thread_notification &&
+                // (iohcRadio::_g_payload ||
+                    // iohcRadio::_g_preamble)) {
+                (iohcRadio::radioState == iohcRadio::RadioState::PAYLOAD ||
+                 iohcRadio::radioState == iohcRadio::RadioState::PREAMBLE)) {
+
                 iohcRadio::tickerCounter(static_cast<iohcRadio *>(pvParameters));
-                --thread_notification;
             }
         }
     }
@@ -160,12 +164,12 @@ namespace IOHC {
         // Radio::calibrate();
         Radio::setRx();
 
-#if defined(ESP32)
-        if (TickTimer.active()) {
-            TickTimer.detach();
-        }
-        TickTimer.attach_us(SM_GRANULARITY_US, onScanTicker, this);
-#endif
+//#if defined(ESP32)
+//        if (TickTimer.active()) {
+//            TickTimer.detach();
+//        }
+//        TickTimer.attach_us(SM_GRANULARITY_US, tickerCounter, this);
+//#endif
     }
 
 /**
@@ -234,15 +238,6 @@ namespace IOHC {
 
         Radio::setCarrier(Radio::Carrier::Frequency, radio->scan_freqs[radio->currentFreqIdx]);
 
-    }
-
-    void IRAM_ATTR iohcRadio::onScanTicker(void *arg) {
-        (void)arg;
-        if (!handle_interrupt) {
-            return;
-        }
-
-        xTaskNotifyGive(handle_interrupt);
     }
 
     /**

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -58,13 +58,9 @@ namespace IOHC {
         constexpr TickType_t xMaxBlockTime = pdMS_TO_TICKS(655 * 4); // 218.4 );
         while (true) {
             thread_notification = ulTaskNotifyTake(pdTRUE, xMaxBlockTime/*xNoDelay*/); // Attendre la notification
-            if (thread_notification &&
-                // (iohcRadio::_g_payload ||
-                    // iohcRadio::_g_preamble)) {
-                (iohcRadio::radioState == iohcRadio::RadioState::PAYLOAD ||
-                 iohcRadio::radioState == iohcRadio::RadioState::PREAMBLE)) {
-
+            while (thread_notification > 0) {
                 iohcRadio::tickerCounter(static_cast<iohcRadio *>(pvParameters));
+                --thread_notification;
             }
         }
     }
@@ -168,7 +164,7 @@ iohcRadio::setRadioState(iohcRadio::_g_payload ? iohcRadio::RadioState::PAYLOAD 
         if (TickTimer.active()) {
             TickTimer.detach();
         }
-        TickTimer.attach_us(SM_GRANULARITY_US, tickerCounter, this);
+        TickTimer.attach_us(SM_GRANULARITY_US, onScanTicker, this);
 #endif
     }
 
@@ -238,6 +234,15 @@ iohcRadio::setRadioState(iohcRadio::_g_payload ? iohcRadio::RadioState::PAYLOAD 
 
         Radio::setCarrier(Radio::Carrier::Frequency, radio->scan_freqs[radio->currentFreqIdx]);
 
+    }
+
+    void IRAM_ATTR iohcRadio::onScanTicker(void *arg) {
+        (void)arg;
+        if (!handle_interrupt) {
+            return;
+        }
+
+        xTaskNotifyGive(handle_interrupt);
     }
 
     /**


### PR DESCRIPTION
## Summary
- re-enable the ESP32 ticker when starting the radio so the hopping counter advances
- detach any existing ticker instance before attaching to avoid duplicate timers

## Testing
- `pio run` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2786919e48326b112eb799eb75fff