### PR TITLE
Add configurable MQTT port in UI and firmware

### DIFF
--- a/extras/web_interface_data/index.html
+++ b/extras/web_interface_data/index.html
@@ -103,6 +103,8 @@
                         <input type="text" id="mqtt-user" placeholder="MQTT User">
                         <label for="mqtt-server">Server:</label>
                         <input type="text" id="mqtt-server" placeholder="MQTT Server">
+                        <label for="mqtt-port">Port:</label>
+                        <input type="number" id="mqtt-port" placeholder="MQTT Port" min="1" max="65535">
                         <label for="mqtt-password">Password:</label>
                         <input type="password" id="mqtt-password" placeholder="MQTT Password">
                         <label for="mqtt-discovery">Discovery Topic:</label>

--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const MAX_LOGS = 20; // maximaal aantal logs
     const mqttUserInput = document.getElementById('mqtt-user');
     const mqttServerInput = document.getElementById('mqtt-server');
+    const mqttPortInput = document.getElementById('mqtt-port');
     const mqttPasswordInput = document.getElementById('mqtt-password');
     const mqttDiscoveryInput = document.getElementById('mqtt-discovery');
     const mqttUpdateButton = document.getElementById('mqtt-update');
@@ -77,6 +78,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const cfg = await resp.json();
             mqttUserInput.value = cfg.user || '';
             mqttServerInput.value = cfg.server || '';
+            mqttPortInput.value = cfg.port != null ? cfg.port : '';
             mqttPasswordInput.value = cfg.password || '';
             mqttDiscoveryInput.value = cfg.discovery || '';
         } catch (e) {
@@ -91,6 +93,10 @@ document.addEventListener('DOMContentLoaded', function() {
             password: mqttPasswordInput.value,
             discovery: mqttDiscoveryInput.value
         };
+        const portValue = parseInt(mqttPortInput.value, 10);
+        if (!Number.isNaN(portValue)) {
+            payload.port = portValue;
+        }
         try {
             const resp = await fetch('/api/mqtt', {
                 method: 'POST',

--- a/include/nvs_helpers.h
+++ b/include/nvs_helpers.h
@@ -9,6 +9,7 @@ static constexpr char NVS_KEY_MQTT_SERVER[] = "mqtt_server";
 static constexpr char NVS_KEY_MQTT_USER[] = "mqtt_user";
 static constexpr char NVS_KEY_MQTT_PASSWORD[] = "mqtt_password";
 static constexpr char NVS_KEY_MQTT_DISCOVERY[] = "mqtt_disc_topic";
+static constexpr char NVS_KEY_MQTT_PORT[] = "mqtt_port";
 
 
 bool nvs_init();
@@ -17,5 +18,7 @@ void nvs_write_sequence(const IOHC::address addr, uint16_t sequence);
 
 bool nvs_read_string(const char *key, std::string &value);
 void nvs_write_string(const char *key, const std::string &value);
+bool nvs_read_u16(const char *key, uint16_t &value);
+void nvs_write_u16(const char *key, uint16_t value);
 
 #endif // NVS_HELPERS_H

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -34,6 +34,7 @@ inline std::string mqtt_server = "";
 inline std::string mqtt_user = "mosquitto";
 inline std::string mqtt_password = "";
 inline std::string mqtt_discovery_topic = "homeassistant";
+inline uint16_t mqtt_port = 1883;
 
 #define SYSLOG                       // Comment out to disable remote syslog
 inline std::string syslog_server = "192.168.178.15"; // Syslog server IP address

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -293,7 +293,7 @@ void createCommands() {
         nvs_write_string(NVS_KEY_MQTT_SERVER, mqtt_server);
 
         mqttClient.disconnect();
-        mqttClient.setServer(mqtt_server.c_str(), 1883);
+        mqttClient.setServer(mqtt_server.c_str(), mqtt_port);
         connectToMqtt();
     });
     Cmd::addHandler((char *) "mqttUser", (char *) "Set MQTT username", [](Tokens *cmd)-> void {
@@ -320,6 +320,24 @@ void createCommands() {
 
         mqttClient.disconnect();
         mqttClient.setCredentials(mqtt_user.c_str(), mqtt_password.c_str());
+        connectToMqtt();
+    });
+    Cmd::addHandler((char *) "mqttPort", (char *) "Set MQTT port", [](Tokens *cmd)-> void {
+        if (cmd->size() < 2) {
+            Serial.println("Usage: mqttPort <port>");
+            return;
+        }
+        int port = atoi(cmd->at(1).c_str());
+        if (port <= 0 || port > 65535) {
+            Serial.println("Invalid port value");
+            return;
+        }
+        mqtt_port = static_cast<uint16_t>(port);
+
+        nvs_write_u16(NVS_KEY_MQTT_PORT, mqtt_port);
+
+        mqttClient.disconnect();
+        mqttClient.setServer(mqtt_server.c_str(), mqtt_port);
         connectToMqtt();
     });
     Cmd::addHandler((char *) "mqttDiscovery", (char *) "Set MQTT discovery topic", [](Tokens *cmd)-> void {

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -51,10 +51,14 @@ void initMqtt() {
         }
     }
 
+    if (!nvs_read_u16(NVS_KEY_MQTT_PORT, mqtt_port)) {
+        nvs_write_u16(NVS_KEY_MQTT_PORT, mqtt_port);
+    }
+
     mqttClient.setWill(AVAILABILITY_TOPIC, 0, true, "offline");
     mqttClient.setClientId("iown");
     mqttClient.setCredentials(mqtt_user.c_str(), mqtt_password.c_str());
-    mqttClient.setServer(mqtt_server.c_str(), 1883);
+    mqttClient.setServer(mqtt_server.c_str(), mqtt_port);
     mqttClient.onConnect(onMqttConnect);
     mqttClient.onDisconnect(onMqttDisconnect);
     mqttClient.onMessage(onMqttMessage);
@@ -263,7 +267,7 @@ void connectToMqtt() {
         Serial.println("MQTT server not configured");
         return;
     }
-    Serial.printf("Connecting to MQTT at %s...\n", mqtt_server.c_str());
+    Serial.printf("Connecting to MQTT at %s:%u...\n", mqtt_server.c_str(), mqtt_port);
     mqttStatus = ConnState::Connecting;
     updateDisplayStatus();
     mqttClient.connect();

--- a/src/nvs_helpers.cpp
+++ b/src/nvs_helpers.cpp
@@ -38,3 +38,15 @@ void nvs_write_string(const char *key, const std::string &value) {
     if (!nvs_init()) return;
     prefs.putString(key, value.c_str());
 }
+
+bool nvs_read_u16(const char *key, uint16_t &value) {
+    if (!nvs_init()) return false;
+    if (!prefs.isKey(key)) return false;
+    value = prefs.getUShort(key, value);
+    return true;
+}
+
+void nvs_write_u16(const char *key, uint16_t value) {
+    if (!nvs_init()) return;
+    prefs.putUShort(key, value);
+}


### PR DESCRIPTION
## Summary
- persist an editable MQTT port alongside server credentials in NVS and CLI
- expose the port through the web API and update the web UI to allow user changes
- add NVS helpers for 16-bit values and update MQTT logging to include the port

## Testing
- Not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e55e343a0883269f653adc28f5f97e