### PR TITLE
Allow configuring MQTT client ID via web UI

### DIFF
--- a/extras/web_interface_data/index.html
+++ b/extras/web_interface_data/index.html
@@ -99,6 +99,8 @@
                         <h2>MQTT settings</h2>
                     </div>
                     <div class="card">
+                        <label for="mqtt-client-id">Client ID:</label>
+                        <input type="text" id="mqtt-client-id" placeholder="MQTT Client ID">
                         <label for="mqtt-user">User:</label>
                         <input type="text" id="mqtt-user" placeholder="MQTT User">
                         <label for="mqtt-server">Server:</label>

--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const sendCommandButton = document.getElementById('send-command-button');
     const statusMessagesDiv = document.getElementById('status-messages');
     const MAX_LOGS = 20; // maximaal aantal logs
+    const mqttClientIdInput = document.getElementById('mqtt-client-id');
     const mqttUserInput = document.getElementById('mqtt-user');
     const mqttServerInput = document.getElementById('mqtt-server');
     const mqttPortInput = document.getElementById('mqtt-port');
@@ -76,6 +77,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const resp = await fetch('/api/mqtt');
             if (!resp.ok) return;
             const cfg = await resp.json();
+            mqttClientIdInput.value = cfg.clientId || '';
             mqttUserInput.value = cfg.user || '';
             mqttServerInput.value = cfg.server || '';
             mqttPortInput.value = cfg.port != null ? cfg.port : '';
@@ -88,6 +90,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // update MQTT config
     async function updateMqttConfig() {
         const payload = {
+            clientId: mqttClientIdInput.value,
             user: mqttUserInput.value,
             server: mqttServerInput.value,
             password: mqttPasswordInput.value,

--- a/include/nvs_helpers.h
+++ b/include/nvs_helpers.h
@@ -9,6 +9,7 @@ static constexpr char NVS_KEY_MQTT_SERVER[] = "mqtt_server";
 static constexpr char NVS_KEY_MQTT_USER[] = "mqtt_user";
 static constexpr char NVS_KEY_MQTT_PASSWORD[] = "mqtt_password";
 static constexpr char NVS_KEY_MQTT_DISCOVERY[] = "mqtt_disc_topic";
+static constexpr char NVS_KEY_MQTT_CLIENT_ID[] = "mqtt_client_id";
 static constexpr char NVS_KEY_MQTT_PORT[] = "mqtt_port";
 
 

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -30,6 +30,7 @@ inline const char *wifi_passwd = "";
 
 // Default MQTT configuration. These values can be changed at runtime through
 // the interactive command interface. Leave empty to rely on stored values.
+inline std::string mqtt_client_id = "iown";
 inline std::string mqtt_server = "";
 inline std::string mqtt_user = "mosquitto";
 inline std::string mqtt_password = "";

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -309,6 +309,19 @@ void createCommands() {
         mqttClient.setCredentials(mqtt_user.c_str(), mqtt_password.c_str());
         connectToMqtt();
     });
+    Cmd::addHandler((char *) "mqttId", (char *) "Set MQTT client ID", [](Tokens *cmd)-> void {
+        if (cmd->size() < 2) {
+            Serial.println("Usage: mqttId <id>");
+            return;
+        }
+        mqtt_client_id = cmd->at(1);
+
+        nvs_write_string(NVS_KEY_MQTT_CLIENT_ID, mqtt_client_id);
+
+        mqttClient.disconnect();
+        mqttClient.setClientId(mqtt_client_id.c_str());
+        connectToMqtt();
+    });
     Cmd::addHandler((char *) "mqttPass", (char *) "Set MQTT password", [](Tokens *cmd)-> void {
         if (cmd->size() < 2) {
             Serial.println("Usage: mqttPass <password>");

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -50,13 +50,20 @@ void initMqtt() {
             nvs_write_string(NVS_KEY_MQTT_DISCOVERY, mqtt_discovery_topic);
         }
     }
+    if (!nvs_read_string(NVS_KEY_MQTT_CLIENT_ID, mqtt_client_id)) {
+        if (mqtt_client_id.empty()) {
+            Serial.println("MQTT client id not set");
+        } else {
+            nvs_write_string(NVS_KEY_MQTT_CLIENT_ID, mqtt_client_id);
+        }
+    }
 
     if (!nvs_read_u16(NVS_KEY_MQTT_PORT, mqtt_port)) {
         nvs_write_u16(NVS_KEY_MQTT_PORT, mqtt_port);
     }
 
     mqttClient.setWill(AVAILABILITY_TOPIC, 0, true, "offline");
-    mqttClient.setClientId("iown");
+    mqttClient.setClientId(mqtt_client_id.c_str());
     mqttClient.setCredentials(mqtt_user.c_str(), mqtt_password.c_str());
     mqttClient.setServer(mqtt_server.c_str(), mqtt_port);
     mqttClient.onConnect(onMqttConnect);

--- a/src/web_server_handler.cpp
+++ b/src/web_server_handler.cpp
@@ -397,6 +397,7 @@ void handleApiMqttGet(AsyncWebServerRequest *request) {
   root["user"] = mqtt_user.c_str();
   root["password"] = mqtt_password.c_str();
   root["discovery"] = mqtt_discovery_topic.c_str();
+  root["clientId"] = mqtt_client_id.c_str();
   root["port"] = mqtt_port;
   response->setLength();
   request->send(response);
@@ -419,6 +420,7 @@ void handleApiMqttSet(AsyncWebServerRequest *request, JsonVariant &json) {
   String user = doc["user"] | "";
   String password = doc["password"] | "";
   String discovery = doc["discovery"] | "";
+  String clientId = doc["clientId"] | "";
   int portValue = -1;
   if (doc.containsKey("port")) {
     JsonVariant portVariant = doc["port"];
@@ -452,6 +454,11 @@ void handleApiMqttSet(AsyncWebServerRequest *request, JsonVariant &json) {
     nvs_write_string(NVS_KEY_MQTT_DISCOVERY, mqtt_discovery_topic);
     discChanged = true;
   }
+  if (!clientId.isEmpty() && mqtt_client_id != clientId.c_str()) {
+    mqtt_client_id = clientId.c_str();
+    nvs_write_string(NVS_KEY_MQTT_CLIENT_ID, mqtt_client_id);
+    mqttChanged = true;
+  }
 
   if (portValue > 0 && portValue <= 65535 && mqtt_port != static_cast<uint16_t>(portValue)) {
     mqtt_port = static_cast<uint16_t>(portValue);
@@ -463,6 +470,7 @@ void handleApiMqttSet(AsyncWebServerRequest *request, JsonVariant &json) {
     mqttClient.disconnect();
     mqttClient.setServer(mqtt_server.c_str(), mqtt_port);
     mqttClient.setCredentials(mqtt_user.c_str(), mqtt_password.c_str());
+    mqttClient.setClientId(mqtt_client_id.c_str());
   }
 
   if (discChanged && mqttStatus == ConnState::Connected) {


### PR DESCRIPTION
## Summary
- add persistent storage for the MQTT client ID and use it when connecting
- expose the client ID through the CLI and REST endpoints so it can be changed at runtime
- update the web UI settings page to edit the MQTT client ID alongside other broker fields

## Testing
- not run (hardware dependent)


------
https://chatgpt.com/codex/tasks/task_e_68e565e90440832695811c2fe6fe54ce