### PR TITLE
Add syslog configuration controls to web settings

### DIFF
--- a/extras/web_interface_data/index.html
+++ b/extras/web_interface_data/index.html
@@ -114,6 +114,22 @@
                         <button id="mqtt-update">Update</button>
                     </div>
                 </section>
+                <section id="syslog-settings-section">
+                    <div class="title">
+                        <h2>Syslog settings</h2>
+                    </div>
+                    <div class="card">
+                        <label class="checkbox-inline" for="syslog-enabled">
+                            <input type="checkbox" id="syslog-enabled">
+                            Enable syslog forwarding
+                        </label>
+                        <label for="syslog-server">Server:</label>
+                        <input type="text" id="syslog-server" placeholder="Syslog Server">
+                        <label for="syslog-port">Port:</label>
+                        <input type="number" id="syslog-port" placeholder="Syslog Port" min="1" max="65535">
+                        <button id="syslog-update">Update</button>
+                    </div>
+                </section>
                 <section id="update-section">
                     <div class="title">
                         <h2>Update</h2>

--- a/include/nvs_helpers.h
+++ b/include/nvs_helpers.h
@@ -11,6 +11,9 @@ static constexpr char NVS_KEY_MQTT_PASSWORD[] = "mqtt_password";
 static constexpr char NVS_KEY_MQTT_DISCOVERY[] = "mqtt_disc_topic";
 static constexpr char NVS_KEY_MQTT_CLIENT_ID[] = "mqtt_client_id";
 static constexpr char NVS_KEY_MQTT_PORT[] = "mqtt_port";
+static constexpr char NVS_KEY_SYSLOG_ENABLED[] = "syslog_enabled";
+static constexpr char NVS_KEY_SYSLOG_SERVER[] = "syslog_server";
+static constexpr char NVS_KEY_SYSLOG_PORT[] = "syslog_port";
 
 
 bool nvs_init();
@@ -21,5 +24,7 @@ bool nvs_read_string(const char *key, std::string &value);
 void nvs_write_string(const char *key, const std::string &value);
 bool nvs_read_u16(const char *key, uint16_t &value);
 void nvs_write_u16(const char *key, uint16_t value);
+bool nvs_read_bool(const char *key, bool &value);
+void nvs_write_bool(const char *key, bool value);
 
 #endif // NVS_HELPERS_H

--- a/include/syslog_helper.h
+++ b/include/syslog_helper.h
@@ -11,6 +11,9 @@
 // Initialize UDP + target IP from user_config.h
 void initSyslog();
 
+// Reset the UDP sender state so that configuration changes are applied
+void resetSyslog();
+
 // Legacy signature (no severity)
 void sendSyslog(const String &msg);
 

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -38,6 +38,7 @@ inline std::string mqtt_discovery_topic = "homeassistant";
 inline uint16_t mqtt_port = 1883;
 
 #define SYSLOG                       // Comment out to disable remote syslog
+inline bool syslog_enabled = true;     // Allow runtime control of syslog forwarding
 inline std::string syslog_server = "192.168.178.15"; // Syslog server IP address
 inline uint16_t syslog_port = 514;     // Syslog server port
 

--- a/src/nvs_helpers.cpp
+++ b/src/nvs_helpers.cpp
@@ -50,3 +50,15 @@ void nvs_write_u16(const char *key, uint16_t value) {
     if (!nvs_init()) return;
     prefs.putUShort(key, value);
 }
+
+bool nvs_read_bool(const char *key, bool &value) {
+    if (!nvs_init()) return false;
+    if (!prefs.isKey(key)) return false;
+    value = prefs.getBool(key, value);
+    return true;
+}
+
+void nvs_write_bool(const char *key, bool value) {
+    if (!nvs_init()) return;
+    prefs.putBool(key, value);
+}


### PR DESCRIPTION
## Summary
- add syslog enable/server/port controls to the web settings UI with load/update logic
- persist syslog configuration in NVS and expose `/api/syslog` GET/POST handlers
- extend the syslog helper to honour runtime enable/disable, reload stored values, and reset the UDP sender

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e57b6474e48326aedf7dcfb443ce5b