### PR TITLE
fix(#166) : update oled_rst pin according to board

### DIFF
--- a/include/board-config.h
+++ b/include/board-config.h
@@ -45,12 +45,15 @@
 #if defined(LILYGO)
 #define I2C_SDA_PIN 21
 #define I2C_SCL_PIN 22
+#define DISPLAY_OLED_RST_PIN 14
 #elif defined(HELTEC)
 #define I2C_SDA_PIN 4
 #define I2C_SCL_PIN 15
+#define DISPLAY_OLED_RST_PIN 16
 #else
 #define I2C_SDA_PIN 21
 #define I2C_SCL_PIN 22
+#define DISPLAY_OLED_RST_PIN 16
 #endif
 
 // OK LilyGo Wifi ESP32 Lora v2.1.6

--- a/include/oled_display.h
+++ b/include/oled_display.h
@@ -14,7 +14,7 @@
 #define OLED_ADDRESS 0x3c
 #define OLED_SDA     I2C_SDA_PIN
 #define OLED_SCL     I2C_SCL_PIN
-#define OLED_RST     16
+#define OLED_RST     DISPLAY_OLED_RST_PIN
 #define SCREEN_WIDTH 128
 #define SCREEN_HEIGHT 64
 


### PR DESCRIPTION
When flashing a LilyGo LoRa32 T3 V1.6.1, the board is looping on setup function and resetting rigth after LCD screen is initialized.
When commenting out the "#define SSD1306_DISPLAY" from user_config.h, the board is working properly, so i found the screen was the culprit.
According to https://github.com/LilyGO/ESP32-Paxcounter/blob/master/src/hal/ttgov2.h, the oled reset pin on a lillygo board is 14, so I updated the board-config.h.
When flashing my lillygo like that, it's working for me now with the screen, hope this can help