### PR TITLE
Support for upload on mac

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -81,7 +81,7 @@ lib_deps =
 ;	https://github.com/jgromes/RadioLib.git@6.6.0
 
 upload_protocol = esptool
-upload_speed = 921600
+upload_speed = 460800 # safer for *nix systems
 monitor_speed = 115200
 monitor_echo = true
 monitor_filters = esp32_exception_decoder, send_on_enter, time, colorize


### PR DESCRIPTION
This change allows for upload on Mac systems. Apparently the upload speed was too high, causing issues like:
```
A fatal error occurred: Unable to verify flash chip connection (Invalid head of packet (0xE0): Possible serial noise or corruption.).
```
or
```
A fatal error occurred: Unable to verify flash chip connection (Packet content transfer stopped (received 7 bytes)).
```