### PR TITLE
Fix renaming remote

### DIFF
--- a/extras/script.js
+++ b/extras/script.js
@@ -774,7 +774,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         const response = await fetch('/api/command', {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ RemoteId: remoteId, command: `editRemote ${newName}` })
+                            body: JSON.stringify({ command: `editRemote ${remoteId} ${newName}` })
                         });
                         const result = await response.json();
                         if (result.success) {

--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -839,7 +839,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         const response = await fetch('/api/command', {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ RemoteId: remoteId, command: `editRemote ${newName}` })
+                            body: JSON.stringify({ command: `editRemote ${remoteId} ${newName}` })
                         });
                         const result = await response.json();
                         if (result.success) {

--- a/include/iohcRemoteMap.h
+++ b/include/iohcRemoteMap.h
@@ -24,6 +24,7 @@ namespace IOHC {
         bool add(const address node, const std::string &name);
         bool linkDevice(const address node, const std::string &device);
         bool unlinkDevice(const address node, const std::string &device);
+        bool renameDevice(const address node, const std::string &name);
         bool remove(const address node);
         const std::vector<entry>& getEntries() const;
 

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -199,6 +199,22 @@ void createCommands() {
         }
         IOHC::iohcRemoteMap::getInstance()->add(node, name);
     });
+    Cmd::addHandler((char *) "editRemote", (char *) "Edit remote name", [](Tokens *cmd)-> void {
+        if (cmd->size() < 2) {
+            Serial.println("Usage: editRemote <address> <name>");
+            return;
+        }
+        IOHC::address node{};
+        if (hexStringToBytes(cmd->at(1), node) != sizeof(IOHC::address)) {
+            Serial.println("Invalid address");
+            return;
+        }
+        std::string name = cmd->at(2);
+        for (size_t i = 3; i < cmd->size(); ++i) {
+            name += " " + cmd->at(i);
+        }
+        IOHC::iohcRemoteMap::getInstance()->renameDevice(node, name);
+    });
     Cmd::addHandler((char *) "linkRemote", (char *) "Link device to remote", [](Tokens *cmd)-> void {
         if (cmd->size() < 3) {
             Serial.println("Usage: linkRemote <address> <device>");

--- a/src/iohcRemoteMap.cpp
+++ b/src/iohcRemoteMap.cpp
@@ -137,6 +137,17 @@ namespace IOHC {
         return false;
     }
 
+    bool iohcRemoteMap::renameDevice(const address node, const std::string &name) {
+        auto it = std::find_if(_entries.begin(), _entries.end(),
+                               [&](const entry &e) { return memcmp(e.node, node, sizeof(address)) == 0; });
+        if (it == _entries.end()) {
+            Serial.println("Remote not found");
+            return false;
+        }
+        it->name = name;
+        return save();
+    }
+
     bool iohcRemoteMap::remove(const address node) {
         auto it = std::find_if(_entries.begin(), _entries.end(),
                                [&](const entry &e) { return memcmp(e.node, node, sizeof(address)) == 0; });


### PR DESCRIPTION
Apparently renaming a remote was not implemented yet. This PR contains the fix to allow renaming remotes.