### PR TITLE
Add per-device blind/light mode for HA discovery and control

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ This feature is under development, and functionality will be expanded in the fut
 
 ## Home Assistant Discovery
 
-When MQTT is enabled (`#define MQTT` in `include/user_config.h`), the firmware publishes HA discovery messages for every blind.  
+When MQTT is enabled (`#define MQTT` in `include/user_config.h`), the firmware publishes HA discovery messages for every configured 1W device (blind or light).  
 
 
 The `1W.json` file now accepts an optional `travel_time` field per device. This value represents the time in seconds a blind takes to move from fully closed to fully open. It allows the firmware to estimate the current position when no feedback is available. The estimated position is printed to the serial console and shown on the OLED display every second while the blind is moving. When a command is transmitted or received, this position feedback is appended below the action information on the display so that the original message remains visible.
@@ -130,13 +130,15 @@ Each blind also publishes a Home Assistant number entity for the travel time. Ad
 
 Each entry can also contain a `paired` boolean that indicates if the blind is paired to a screen. If the field is missing, it is automatically added with a default value of `false` when the file is loaded. The flag is updated automatically when the `pair` or `remove` commands are used.
 
+Each entry can include a `kind` field (`"blind"` or `"light"`). `blind` is the default. When set to `light`, the device is published as a Home Assistant MQTT light and can be controlled with `ON`/`OFF` over `iown/<id>/light/set`.
+
 Sequence numbers for each remote are stored both in `extras/1W.json` and in NVS.
 On boot the value from the file is compared to the one in NVS and the highest
 value is kept so sequence numbers continue uninterrupted even after filesystem
 uploads or resets.
 
 
-It supports `travel_time`, pairing state, and sequence numbers.  
+It supports `travel_time`, pairing state, device kind (`blind`/`light`), and sequence numbers.  
 
 Example payload:  
 ```json
@@ -159,7 +161,7 @@ device list.
 Sending `PRESS` to `iown/<id>/pair`, `iown/<id>/add` or `iown/<id>/remove`
 triggers the corresponding command on the blind.
 
-Configure your MQTT broker settings in `include/user_config.h` (`mqtt_server`, `mqtt_user`, `mqtt_password`, `mqtt_discovery_topic`). These values can also be changed at runtime via the `mqttIp`, `mqttUser`, `mqttPass` and `mqttDiscovery` commands. After boot and connection, Home Assistant should automatically discover the covers.
+Configure your MQTT broker settings in `include/user_config.h` (`mqtt_server`, `mqtt_user`, `mqtt_password`, `mqtt_discovery_topic`). These values can also be changed at runtime via the `mqttIp`, `mqttUser`, `mqttPass` and `mqttDiscovery` commands. After boot and connection, Home Assistant should automatically discover the covers/lights. You can switch a device type at runtime with `type1W <description> <blind|light>`.
 
 If you don't have an OLED display connected, comment out the `DISPLAY` definition in `include/user_config.h` to disable all display related code.
 

--- a/extras/script.js
+++ b/extras/script.js
@@ -280,7 +280,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
                 // 🔘 up btn
                 const upButton = document.createElement('button');
-                upButton.textContent = 'up';
+                upButton.textContent = device.kind === 'light' ? 'on' : 'up';
                 upButton.classList.add('btn', 'open');
                 upButton.onclick = () => {
                     fetch('/api/action', {
@@ -302,7 +302,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 };
                 // 🔘 down btn
                 const downButton = document.createElement('button');
-                downButton.textContent = 'down';
+                downButton.textContent = device.kind === 'light' ? 'off' : 'down';
                 downButton.classList.add('btn', 'down');
                 downButton.onclick = () => {
                     fetch('/api/action', {
@@ -321,6 +321,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             'Description: ' + (device.description || ''),
                             'Position: ' + device.position + '%',
                             'Paired: ' + (device.paired ? 'Yes' : 'No'),
+                            'Type: ' + ((device.kind || 'blind') === 'light' ? 'Light' : 'Blind'),
                         ], [""], {
                         showSave: true,
                         showInput: true,
@@ -329,11 +330,11 @@ document.addEventListener('DOMContentLoaded', function() {
                         defaultValue: device.name,
                         defaultTiming: device.travel_time,
                         showBoolean: true,
-                        booleanLabel: 'Active',
-                        defaultBoolean: device.active,  // bv. uit je data
+                        booleanLabel: 'Use as light (instead of blind)',
+                        defaultBoolean: (device.kind || 'blind') === 'light',
                         pairLabel: 'Add / Remove the device to the physical screen',
                         deleteInfo: 'Only use when the device is not linked to a physical screen.',
-                        onSave: async (newName, newTiming) => {
+                        onSave: async (newName, newTiming, _deviceValue, isLight) => {
                             try {
                                 if (newName.trim() && newName !== device.name) {
                                     const response = await fetch('/api/command', {
@@ -360,6 +361,20 @@ document.addEventListener('DOMContentLoaded', function() {
                                         logStatus(tResult.message || 'Travel time updated.');
                                     } else {
                                         logStatus(tResult.message || 'Failed to update travel time.', true);
+                                    }
+                                }
+                                const targetType = isLight ? 'light' : 'blind';
+                                if (targetType !== (device.kind || 'blind')) {
+                                    const typeResp = await fetch('/api/command', {
+                                        method: 'POST',
+                                        headers: { 'Content-Type': 'application/json' },
+                                        body: JSON.stringify({ deviceId: device.id, command: `type1W ${targetType}` })
+                                    });
+                                    const typeResult = await typeResp.json();
+                                    if (typeResult.success) {
+                                        logStatus(typeResult.message || 'Device type updated.');
+                                    } else {
+                                        logStatus(typeResult.message || 'Failed to update device type.', true);
                                     }
                                 }
                                 fetchAndDisplayDevices();
@@ -595,6 +610,7 @@ document.addEventListener('DOMContentLoaded', function() {
         boolRow.style.display = showBoolean ? 'flex' : 'none';
         if (showBoolean) {
             boolInput.checked = !!options.defaultBoolean;
+            boolLabel.textContent = options.booleanLabel || "Enabled";
         }
         const showInput = options && options.showInput;
         input.style.display = showInput ? 'block' : 'none';
@@ -703,7 +719,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const timingValue = showTiming ? inputTiming.value : undefined;
             const deviceValue = showDevicePopup ? devicePopup.value : undefined;
             closePopup();
-            if (options.onSave) options.onSave(value, timingValue, deviceValue);
+            if (options.onSave) options.onSave(value, timingValue, deviceValue, boolInput.checked);
         };
 
         // add/remove buttons handled above

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -48,6 +48,11 @@ namespace IOHC {
 
     class iohcRemote1W : public iohcDevice {
     public:
+        enum class DeviceKind {
+            Blind,
+            Light
+        };
+
         struct remote {
             address node{};
             uint16_t sequence{};
@@ -55,6 +60,7 @@ namespace IOHC {
             std::vector<uint8_t> type{};
             uint8_t manufacturer{};
             bool paired{false};
+            DeviceKind kind{DeviceKind::Blind};
             std::string description;
             std::string name;
             uint32_t travelTime{}; // seconds to fully open or close
@@ -81,7 +87,11 @@ namespace IOHC {
         bool removeRemote(const std::string &description);
         bool renameRemote(const std::string &description, const std::string &name);
         bool setTravelTime(const std::string &description, uint32_t travelTime);
+        bool setDeviceKind(const std::string &description, DeviceKind kind);
         void updatePositions();
+
+        static DeviceKind parseDeviceKind(const std::string &value);
+        static const char* deviceKindToString(DeviceKind kind);
 
     private:
         iohcRemote1W();

--- a/include/mqtt_handler.h
+++ b/include/mqtt_handler.h
@@ -24,7 +24,7 @@ void onMqttDisconnect(AsyncMqttClientDisconnectReason reason);
 void onMqttMessage(char *topic, char *payload,
                    AsyncMqttClientMessageProperties properties,
                    size_t len, size_t index, size_t total);
-void publishDiscovery(const std::string &id, const std::string &name, const std::string &key);
+void publishDiscovery(const std::string &id, const std::string &name, const std::string &key, bool asLight = false);
 void publishTravelTimeDiscovery(const std::string &id, const std::string &name,
                                 const std::string &key, uint32_t travelTime);
 void handleMqttConnect();

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -172,14 +172,23 @@ void createCommands() {
         uint32_t t = strtoul(cmd->at(2).c_str(), nullptr, 10);
         IOHC::iohcRemote1W::getInstance()->setTravelTime(cmd->at(1), t);
     });
+    Cmd::addHandler((char *) "type1W", (char *) "Set 1W device type (blind|light)", [](Tokens *cmd)-> void {
+        if (cmd->size() < 3) {
+            Serial.println("Usage: type1W <description> <blind|light>");
+            return;
+        }
+        auto kind = IOHC::iohcRemote1W::parseDeviceKind(cmd->at(2));
+        IOHC::iohcRemote1W::getInstance()->setDeviceKind(cmd->at(1), kind);
+    });
     Cmd::addHandler((char *) "list1W", (char *) "List 1W devices", [](Tokens *cmd)-> void {
         const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
         for (const auto &r : remotes) {
-            Serial.printf("%s: %s %u %s\n",
+            Serial.printf("%s: %s %u %s %s\n",
                           r.description.c_str(),
                           r.name.c_str(),
                           r.travelTime,
-                          r.paired ? "paired" : "unpaired");
+                          r.paired ? "paired" : "unpaired",
+                          IOHC::iohcRemote1W::deviceKindToString(r.kind));
         }
     });
     // Remote map

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -64,6 +64,23 @@ namespace IOHC {
         }
     }
 
+    const char* iohcRemote1W::deviceKindToString(DeviceKind kind) {
+        switch (kind) {
+            case DeviceKind::Light: return "light";
+            case DeviceKind::Blind:
+            default: return "blind";
+        }
+    }
+
+    iohcRemote1W::DeviceKind iohcRemote1W::parseDeviceKind(const std::string &value) {
+        std::string normalized = value;
+        std::transform(normalized.begin(), normalized.end(), normalized.begin(), ::tolower);
+        if (normalized == "light") {
+            return DeviceKind::Light;
+        }
+        return DeviceKind::Blind;
+    }
+
     iohcRemote1W::iohcRemote1W() = default;
 
     iohcRemote1W* iohcRemote1W::getInstance() {
@@ -734,6 +751,14 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
                 r.paired = false;
                 updateFile = true;
             }
+
+            if (jobj["kind"].is<const char *>()) {
+                r.kind = parseDeviceKind(jobj["kind"].as<const char *>());
+            } else {
+                r.kind = DeviceKind::Blind;
+                updateFile = true;
+            }
+
             r.positionTracker.setTravelTime(r.travelTime);
 
             remotes.push_back(r);
@@ -780,6 +805,7 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
             jobj["travel_time"] = r.travelTime;
 
             jobj["paired"] = r.paired;
+            jobj["kind"] = deviceKindToString(r.kind);
         }
         serializeJson(doc, f);
         f.close();
@@ -814,6 +840,7 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
         r.name = name;
         r.travelTime = DEFAULT_TRAVEL_TIME_SEC;
         r.paired = false;
+        r.kind = DeviceKind::Blind;
 
         // Generate unique description
         const char letters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -835,7 +862,7 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
         if (mqttClient.connected()) {
             std::string id = bytesToHexString(r.node, sizeof(r.node));
             std::string key = bytesToHexString(r.key, sizeof(r.key));
-            publishDiscovery(id, r.name, key);
+            publishDiscovery(id, r.name, key, r.kind == DeviceKind::Light);
             publishTravelTimeDiscovery(id, r.name, key, r.travelTime);
             mqttClient.subscribe(("iown/" + id + "/set").c_str(), 0);
             mqttClient.subscribe(("iown/" + id + "/position/set").c_str(), 0);
@@ -892,7 +919,7 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
         if (mqttClient.connected()) {
             std::string id = bytesToHexString(it->node, sizeof(it->node));
             std::string key = bytesToHexString(it->key, sizeof(it->key));
-            publishDiscovery(id, it->name, key);
+            publishDiscovery(id, it->name, key, it->kind == DeviceKind::Light);
             publishTravelTimeDiscovery(id, it->name, key, it->travelTime);
         }
 #endif
@@ -969,6 +996,30 @@ const std::vector<iohcRemote1W::remote>& iohcRemote1W::getRemotes() const {
         it->travelTime = travelTime;
         it->positionTracker.setTravelTime(travelTime);
         save();
+        return true;
+    }
+
+
+    bool iohcRemote1W::setDeviceKind(const std::string &description, DeviceKind kind) {
+        auto it = std::find_if(remotes.begin(), remotes.end(), [&](const remote &e) {
+            return e.description == description;
+        });
+        if (it == remotes.end()) {
+            Serial.printf("Device %s not found\n", description.c_str());
+            return false;
+        }
+
+        it->kind = kind;
+        save();
+
+#if defined(MQTT)
+        if (mqttClient.connected()) {
+            std::string id = bytesToHexString(it->node, sizeof(it->node));
+            std::string key = bytesToHexString(it->key, sizeof(it->key));
+            publishDiscovery(id, it->name, key, it->kind == DeviceKind::Light);
+            publishTravelTimeDiscovery(id, it->name, key, it->travelTime);
+        }
+#endif
         return true;
     }
 

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -134,30 +134,38 @@ void publishTravelTimeDiscovery(const std::string &id, const std::string &name,
     mqttClient.publish(stateTopic.c_str(), 0, true, value.c_str());
 }
 
-void publishDiscovery(const std::string &id, const std::string &name, const std::string &key) {
+void publishDiscovery(const std::string &id, const std::string &name, const std::string &key, bool asLight) {
     JsonDocument doc;
     doc["name"] = name;
     doc["unique_id"] = id;
     doc["command_topic"] = "iown/" + id + "/set";
     doc["state_topic"] = "iown/" + id + "/state";
-    doc["position_topic"] = "iown/" + id + "/position";
-    doc["set_position_topic"] = "iown/" + id + "/position/set";
     doc["availability_topic"] = AVAILABILITY_TOPIC;
     doc["payload_available"] = "online";
     doc["payload_not_available"] = "offline";
-    doc["payload_open"] = "OPEN";
-    doc["payload_close"] = "CLOSE";
-    doc["payload_stop"] = "STOP";
-    doc["state_closed"] = "CLOSE";
-    doc["state_open"] = "OPEN";
-    doc["state_closing"] = "CLOSING";
-    doc["state_opening"] = "OPENING";
-    doc["state_stopped"] = "STOP";
-    doc["device_class"] = "blind";
     doc["expire_after"] = 120;
     doc["optimistic"] = false;
     doc["retain"] = true;
     doc["qos"] = 0;
+
+    if (asLight) {
+        doc["command_topic"] = "iown/" + id + "/light/set";
+        doc["state_topic"] = "iown/" + id + "/light/state";
+        doc["payload_on"] = "ON";
+        doc["payload_off"] = "OFF";
+    } else {
+        doc["position_topic"] = "iown/" + id + "/position";
+        doc["set_position_topic"] = "iown/" + id + "/position/set";
+        doc["payload_open"] = "OPEN";
+        doc["payload_close"] = "CLOSE";
+        doc["payload_stop"] = "STOP";
+        doc["state_closed"] = "CLOSE";
+        doc["state_open"] = "OPEN";
+        doc["state_closing"] = "CLOSING";
+        doc["state_opening"] = "OPENING";
+        doc["state_stopped"] = "STOP";
+        doc["device_class"] = "blind";
+    }
 
     JsonObject device = doc["device"].to<JsonObject>();
     device["identifiers"] = id;
@@ -171,7 +179,7 @@ void publishDiscovery(const std::string &id, const std::string &name, const std:
     std::string payload;
     size_t len = serializeJson(doc, payload);
 
-    std::string topic = mqtt_discovery_topic + "/cover/" + id + "/config";
+    std::string topic = mqtt_discovery_topic + (asLight ? "/light/" : "/cover/") + id + "/config";
     mqttClient.publish(topic.c_str(), 0, true, payload.c_str(), len);
 
     publishButtonDiscovery(id, name, "pair", key);
@@ -182,6 +190,8 @@ void publishDiscovery(const std::string &id, const std::string &name, const std:
 void removeDiscovery(const std::string &id) {
     std::string topic = mqtt_discovery_topic + "/cover/" + id + "/config";
     mqttClient.publish(topic.c_str(), 0, true, "", 0);
+    std::string lightTopic = mqtt_discovery_topic + "/light/" + id + "/config";
+    mqttClient.publish(lightTopic.c_str(), 0, true, "", 0);
 
     auto removeButton = [&](const std::string &action) {
         std::string t = mqtt_discovery_topic + "/button/" + id + "_" + action + "/config";
@@ -241,7 +251,7 @@ static void handleMqttConnectImpl() {
         std::string id = bytesToHexString(r.node, sizeof(r.node));
         std::string key = bytesToHexString(r.key, sizeof(r.key));
         std::string name = r.name.empty() ? r.description : r.name;
-        publishDiscovery(id, name, key);
+        publishDiscovery(id, name, key, r.kind == IOHC::iohcRemote1W::DeviceKind::Light);
         publishTravelTimeDiscovery(id, name, key, r.travelTime);
         //std::string t = "iown/" + id + "/set";
         //mqttClient.subscribe(t.c_str(), 0);
@@ -299,6 +309,7 @@ void onMqttConnect(bool sessionPresent) {
     // mqttClient.subscribe("iown/#", 0);  // DEBUG: later weer weghalen als alles werkt
 
     mqttClient.subscribe("iown/+/set", 0);
+    mqttClient.subscribe("iown/+/light/set", 0);
     mqttClient.subscribe("iown/+/position/set", 0);
     mqttClient.subscribe("iown/+/pair", 0);
     mqttClient.subscribe("iown/+/add", 0);
@@ -446,6 +457,45 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
         return;
     }
 
+    if (topicStr.rfind("iown/", 0) == 0 && topicStr.find("/light/set", 5) != std::string::npos) {
+        std::string id = topicStr.substr(5, topicStr.find("/light/set", 5) - 5);
+        std::transform(id.begin(), id.end(), id.begin(), ::tolower);
+        const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
+        auto it = std::find_if(remotes.begin(), remotes.end(), [&](const auto &r) {
+            return bytesToHexString(r.node, sizeof(r.node)) == id;
+        });
+        if (it != remotes.end()) {
+            std::string stateTopic = "iown/" + id + "/light/state";
+            std::string statePayload = payloadStr;
+            std::transform(statePayload.begin(), statePayload.end(), statePayload.begin(), ::toupper);
+
+            bool handled = false;
+            if (payloadStr == "ON" || payloadStr == "on" || payloadStr == "1" || payloadStr == "OPEN" || payloadStr == "open") {
+                Tokens t;
+                t.push_back("open");
+                t.push_back(it->description);
+                IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Open, &t);
+                statePayload = "ON";
+                handled = true;
+            } else if (payloadStr == "OFF" || payloadStr == "off" || payloadStr == "0" || payloadStr == "CLOSE" || payloadStr == "close") {
+                Tokens t;
+                t.push_back("close");
+                t.push_back(it->description);
+                IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Close, &t);
+                statePayload = "OFF";
+                handled = true;
+            }
+
+            if (handled) {
+                mqttClient.publish(stateTopic.c_str(), 0, true, statePayload.c_str());
+                mqttClient.publish(topicStr.c_str(), 0, true, "", 0);
+            } else {
+                Serial.printf("*> MQTT Unknown light payload %s <*\n", payloadStr.c_str());
+            }
+        }
+        return;
+    }
+
     if (topicStr.rfind("iown/", 0) == 0 && topicStr.find("/set", 5) != std::string::npos) {
         std::string id = topicStr.substr(5, topicStr.find("/set", 5) - 5);
         std::transform(id.begin(), id.end(), id.begin(), ::tolower);
@@ -463,9 +513,17 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
             if (payloadStr == "open") {
                 IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Open, &t);
                 mqttClient.publish(stateTopic.c_str(), 0, true, "OPEN");
+                if (it->kind == IOHC::iohcRemote1W::DeviceKind::Light) {
+                    std::string lightStateTopic = "iown/" + id + "/light/state";
+                    mqttClient.publish(lightStateTopic.c_str(), 0, true, "ON");
+                }
             } else if (payloadStr == "close") {
                 IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Close, &t);
                 mqttClient.publish(stateTopic.c_str(), 0, true, "CLOSE");
+                if (it->kind == IOHC::iohcRemote1W::DeviceKind::Light) {
+                    std::string lightStateTopic = "iown/" + id + "/light/state";
+                    mqttClient.publish(lightStateTopic.c_str(), 0, true, "OFF");
+                }
             } else if (payloadStr == "stop") {
                 IOHC::iohcRemote1W::getInstance()->cmd(IOHC::RemoteButton::Stop, &t);
                 mqttClient.publish(stateTopic.c_str(), 0, true, "STOP");

--- a/src/web_server_handler.cpp
+++ b/src/web_server_handler.cpp
@@ -46,6 +46,7 @@ static void onWsEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
       d["id"] = bytesToHexString(r.node, sizeof(r.node)).c_str();
       d["name"] = r.name.c_str();
       d["position"] = r.positionTracker.getPosition();
+      d["kind"] = IOHC::iohcRemote1W::deviceKindToString(r.kind);
     }
 
     String payload;
@@ -191,6 +192,7 @@ void handleApiDevices(AsyncWebServerRequest *request, JsonArray &root) {
     deviceObj["position"] = r.positionTracker.getPosition();
     deviceObj["travel_time"] = r.travelTime;
     deviceObj["paired"] = r.paired;
+    deviceObj["kind"] = IOHC::iohcRemote1W::deviceKindToString(r.kind);
   }
 
   // Provide a generic command interface as last entry


### PR DESCRIPTION
### Motivation
- Some remotes are used to control binary lights instead of blinds and need to be represented as `light` entities in Home Assistant rather than `cover` entities.
- The firmware should map Open/Close to On/Off for binary devices and expose a per-device option to switch behavior without breaking existing blind handling.

### Description
- Introduce `DeviceKind` and a `kind` field on each `1W` remote, with helpers `parseDeviceKind` and `deviceKindToString`, persisted in `1W.json` with backward-compatible defaults to `blind` (`include/iohcRemote1W.h`, `src/iohcRemote1W.cpp`).
- Add `setDeviceKind` and a CLI command `type1W <description> <blind|light>` to change a device at runtime and include `kind` in `list1W` output (`src/interact.cpp`, `src/iohcRemote1W.cpp`).
- Extend MQTT discovery: change `publishDiscovery` to accept `asLight` and publish either a `cover` or a `light` discovery payload/topic based on `kind`, and ensure discovery removal clears both variants (`include/mqtt_handler.h`, `src/mqtt_handler.cpp`).
- Add MQTT handling for binary light control on `iown/<id>/light/set` (accepts `ON`/`OFF` and tolerant aliases mapped to the same radio commands) and publish corresponding light state updates when legacy `iown/<id>/set` open/close commands are used on a light-typed device (`src/mqtt_handler.cpp`).
- Expose `kind` over the web API and websocket init payload and update the web UI (`extras/script.js`) to show `on/off` labels for lights and allow switching device type from the edit popup (which calls `type1W`).
- Document the new `kind` field and the `type1W` command in the README (`README.md`).

### Testing
- Ran a syntax check on the UI script with `node --check extras/script.js`, which passed.
- Attempted to build with `platformio run` and `python -m platformio run`, but PlatformIO is not available in this environment so build could not be executed.
- Tried to exercise the web UI with Playwright to capture a screenshot, but no web server was reachable on `http://127.0.0.1:80` (`ERR_EMPTY_RESPONSE`), so end-to-end UI validation did not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69985ebe6a68832699f0cba950af02ca)