### PR TITLE
GitHub action

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Generate release tag
         id: generate_release_tag
-        uses: alexvingg/next-release-tag@v1.0.3
+        uses: alexvingg/next-release-tag@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: ''

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Generate release tag
         id: generate_release_tag
-        uses: alexvingg/next-release-tag@main
+        uses: alexvingg/next-release-tag
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: ''

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Generate release tag
         id: generate_release_tag
-        uses: alexvingg/next-release-tag
+        uses: alexvingg/next-release-tag@v1.0.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: ''

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -5,9 +5,7 @@ on:
   push:
     # run on every branch
     branches:
-      - '**'
-    tags:
-      - 'release/*'
+      - 'main'
 
 jobs:
   build-and-release:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,0 +1,104 @@
+name: Build and Release
+
+on:
+  workflow_dispatch:
+  push:
+    # run on every branch
+    branches:
+      - '**'
+    tags:
+      - 'release/*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PlatformIO
+        uses: n-vr/setup-platformio-action@v1
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.14'
+
+      - name: Build PlatformIO project
+        run: pio run 
+    
+
+      - name: Parse platformio.ini (env list + APP_VERSION)
+        id: parse
+        run: |
+          python - <<'PY'
+          import configparser, re, os
+          p = configparser.ConfigParser()
+          p.read('platformio.ini')
+
+          # collect envs defined as [env:NAME]
+          envs = [s.split(':',1)[1] for s in p.sections() if s.startswith('env:')]
+
+          # default_envs from [platformio] section (comma separated)
+          default_envs = []
+          if p.has_section('platformio'):
+            val = p.get('platformio','default_envs',fallback='').strip()
+            if val:
+              default_envs = [x.strip() for x in val.split(',') if x.strip()]
+
+          # Try to extract APP_VERSION from common.build_flags
+          app_version = '0.0.0'
+          if p.has_section('common'):
+            bf = p.get('common','build_flags',fallback='')
+            # Search for -D APP_VERSION in various quoting styles
+            m = re.search(r'-D\s*APP_VERSION\s*=\s*"([^"]+)"', bf)
+            if not m:
+              m = re.search(r"-D\s*APP_VERSION\s*=\s*'([^']+)'", bf)
+            if not m:
+              m = re.search(r'-D\s*APP_VERSION\s*=\s*([^\s\n]+)', bf)
+            if m:
+              app_version = m.group(1).strip('"\'')
+
+          # write outputs and files for later steps
+          with open('envs.txt','w') as f: f.write(','.join(envs))
+          with open('default_envs.txt','w') as f: f.write(','.join(default_envs))
+          with open('app_version.txt','w') as f: f.write(app_version)
+
+          # export outputs for GitHub Actions
+          print(f"envs={','.join(envs)}")
+          print(f"default_envs={','.join(default_envs)}")
+          print(f"app_version={app_version}")
+          ghout = os.environ.get('GITHUB_OUTPUT')
+          if ghout:
+            with open(ghout,'a') as g:
+              g.write(f"envs={','.join(envs)}\n")
+              g.write(f"default_envs={','.join(default_envs)}\n")
+              g.write(f"app_version={app_version}\n")
+          PY
+
+      - name: "✏️ Generate release changelog"
+        uses: janheinrichmerker/action-github-changelog-generator@v2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }} 
+          output: build/release/changelog.md
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Release ${{ steps.parse.outputs.app_version }}
+          body_path: build/release/changelog.md
+          prerelease: github.ref != 'refs/heads/main'
+          files: |
+            build/release/iohomecontrol_HeltecLoraV2ESP32_*.bin
+            build/release/iohomecontrol_HeltecLoraV2ESP32_*.md5
+            build/release/iohomecontrol_LilyGoLoraESP32_*.bin
+            build/release/iohomecontrol_LilyGoLoraESP32_*.md5
+
+      -name: Upload artifacts
+       uses: actions/upload-artifact@v6
+       with:
+         name: build-artifacts
+         path: build/release/

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -43,16 +43,16 @@ jobs:
         run: esptool --chip esp32s3 merge-bin -o HeltecLoraV2ESP32.bin --flash-size 4MB 0x1000 .pio/build/HeltecLoraV2ESP32/bootloader.bin 0x8000 .pio/build/HeltecLoraV2ESP32/partitions.bin 0x10000 .pio/build/HeltecLoraV2ESP32/firmware.bin 0x210000 .pio/build/HeltecLoraV2ESP32/littlefs.bin
 
       - name: "✏️ Generate release changelog"
-        uses: janheinrichmerker/action-github-changelog-generator@v2.3
+        uses: janheinrichmerker/action-github-changelog-generator@v2.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }} 
-          output: build/release/changelog.md
+          output: changelog.md
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ steps.parse.outputs.app_version }}
-          body_path: build/release/changelog.md
+          body_path: changelog.md
           prerelease: github.ref != 'refs/heads/main'
           files: |
             LilyGoLoraESP32.bin
@@ -62,4 +62,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
          name: build-artifacts
-         path: build/release/
+         path: |
+           LilyGoLoraESP32.bin
+           HeltecLoraV2ESP32.bin
+           changelog.md

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           python-version: '3.14'
 
+      - name: install esptools
+        run: pip install -U esptool
+
       - name: Build PlatformIO project
         run: pio run
 

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -28,56 +28,16 @@ jobs:
           python-version: '3.14'
 
       - name: Build PlatformIO project
-        run: pio run 
-    
+        run: pio run
 
-      - name: Parse platformio.ini (env list + APP_VERSION)
-        id: parse
-        run: |
-          python - <<'PY'
-          import configparser, re, os
-          p = configparser.ConfigParser()
-          p.read('platformio.ini')
+      - name: Build filesystem
+        run: pio run -t buildfs
 
-          # collect envs defined as [env:NAME]
-          envs = [s.split(':',1)[1] for s in p.sections() if s.startswith('env:')]
+      - name: Merge bin files together for LilyGoLoraESP32
+        run: esptool --chip esp32s3 merge-bin -o LilyGoLoraESP32.bin --flash-size 4MB 0x1000 .pio/build/LilyGoLoraESP32/bootloader.bin 0x8000 .pio/build/LilyGoLoraESP32/partitions.bin 0x10000 .pio/build/LilyGoLoraESP32/firmware.bin 0x210000 .pio/build/LilyGoLoraESP32/littlefs.bin
 
-          # default_envs from [platformio] section (comma separated)
-          default_envs = []
-          if p.has_section('platformio'):
-            val = p.get('platformio','default_envs',fallback='').strip()
-            if val:
-              default_envs = [x.strip() for x in val.split(',') if x.strip()]
-
-          # Try to extract APP_VERSION from common.build_flags
-          app_version = '0.0.0'
-          if p.has_section('common'):
-            bf = p.get('common','build_flags',fallback='')
-            # Search for -D APP_VERSION in various quoting styles
-            m = re.search(r'-D\s*APP_VERSION\s*=\s*"([^"]+)"', bf)
-            if not m:
-              m = re.search(r"-D\s*APP_VERSION\s*=\s*'([^']+)'", bf)
-            if not m:
-              m = re.search(r'-D\s*APP_VERSION\s*=\s*([^\s\n]+)', bf)
-            if m:
-              app_version = m.group(1).strip('"\'')
-
-          # write outputs and files for later steps
-          with open('envs.txt','w') as f: f.write(','.join(envs))
-          with open('default_envs.txt','w') as f: f.write(','.join(default_envs))
-          with open('app_version.txt','w') as f: f.write(app_version)
-
-          # export outputs for GitHub Actions
-          print(f"envs={','.join(envs)}")
-          print(f"default_envs={','.join(default_envs)}")
-          print(f"app_version={app_version}")
-          ghout = os.environ.get('GITHUB_OUTPUT')
-          if ghout:
-            with open(ghout,'a') as g:
-              g.write(f"envs={','.join(envs)}\n")
-              g.write(f"default_envs={','.join(default_envs)}\n")
-              g.write(f"app_version={app_version}\n")
-          PY
+      - name: Merge bin files together for HeltecLoraV2ESP32
+        run: esptool --chip esp32s3 merge-bin -o HeltecLoraV2ESP32.bin --flash-size 4MB 0x1000 .pio/build/HeltecLoraV2ESP32/bootloader.bin 0x8000 .pio/build/HeltecLoraV2ESP32/partitions.bin 0x10000 .pio/build/HeltecLoraV2ESP32/firmware.bin 0x210000 .pio/build/HeltecLoraV2ESP32/littlefs.bin
 
       - name: "✏️ Generate release changelog"
         uses: janheinrichmerker/action-github-changelog-generator@v2.3
@@ -92,13 +52,11 @@ jobs:
           body_path: build/release/changelog.md
           prerelease: github.ref != 'refs/heads/main'
           files: |
-            build/release/iohomecontrol_HeltecLoraV2ESP32_*.bin
-            build/release/iohomecontrol_HeltecLoraV2ESP32_*.md5
-            build/release/iohomecontrol_LilyGoLoraESP32_*.bin
-            build/release/iohomecontrol_LilyGoLoraESP32_*.md5
+            LilyGoLoraESP32.bin
+            HeltecLoraV2ESP32.bin
 
-      -name: Upload artifacts
-       uses: actions/upload-artifact@v6
-       with:
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
          name: build-artifacts
          path: build/release/

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -45,15 +45,23 @@ jobs:
       - name: "✏️ Generate release changelog"
         uses: janheinrichmerker/action-github-changelog-generator@v2.4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }} 
+          token: ${{ secrets.GITHUB_TOKEN }}
           output: changelog.md
+
+      - name: Generate release tag
+        id: generate_release_tag
+        uses: alexvingg/next-release-tag@v1.0.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: ''
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Release ${{ steps.parse.outputs.app_version }}
+          name: Release ${{ steps.generate_release_tag.outputs.release_tag }}
           body_path: changelog.md
           prerelease: github.ref != 'refs/heads/main'
+          tag_name: ${{ steps.generate_release_tag.outputs.release_tag }}
           files: |
             LilyGoLoraESP32.bin
             HeltecLoraV2ESP32.bin

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -69,12 +69,12 @@ jobs:
           tag_prefix: ''
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
-          name: Release ${{ steps.generate_release_tag.outputs.release_tag }}
+          name: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || steps.generate_release_tag.outputs.release_tag }}
           body_path: changelog.md
-          prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-          tag_name: ${{ steps.generate_release_tag.outputs.release_tag }}
+          prerelease: ${{  !startsWith(github.ref_name, 'v') }}
+          tag_name: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || steps.generate_release_tag.outputs.release_tag }}
           files: |
             LilyGoLoraESP32.bin
             LilyGoLoraESP32_firmware.bin
@@ -86,12 +86,12 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-         name: build-artifacts
-         path: |
-           LilyGoLoraESP32.bin
-           LilyGoLoraESP32_firmware.bin
-           LilyGoLoraESP32_filesystem.bin
-           HeltecLoraV2ESP32.bin
-           HeltecLoraV2ESP32_firmware.bin
-           HeltecLoraV2ESP32_filesystem.bin
-           changelog.md
+          name: build-artifacts
+          path: |
+            LilyGoLoraESP32.bin
+            LilyGoLoraESP32_firmware.bin
+            LilyGoLoraESP32_filesystem.bin
+            HeltecLoraV2ESP32.bin
+            HeltecLoraV2ESP32_firmware.bin
+            HeltecLoraV2ESP32_filesystem.bin
+            changelog.md

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -38,7 +38,14 @@ jobs:
         run: esptool --chip esp32s3 merge-bin -o LilyGoLoraESP32.bin --flash-size 4MB 0x1000 .pio/build/LilyGoLoraESP32/bootloader.bin 0x8000 .pio/build/LilyGoLoraESP32/partitions.bin 0x10000 .pio/build/LilyGoLoraESP32/firmware.bin 0x210000 .pio/build/LilyGoLoraESP32/littlefs.bin
 
       - name: Merge bin files together for HeltecLoraV2ESP32
-        run: esptool --chip esp32s3 merge-bin -o HeltecLoraV2ESP32.bin --flash-size 4MB 0x1000 .pio/build/HeltecLoraV2ESP32/bootloader.bin 0x8000 .pio/build/HeltecLoraV2ESP32/partitions.bin 0x10000 .pio/build/HeltecLoraV2ESP32/firmware.bin 0x210000 .pio/build/HeltecLoraV2ESP32/littlefs.bin
+        run: esptool --chip esp32s3 merge-bin -o HeltecLoraV2ESP32.bin --flash-size 8MB 0x1000 .pio/build/HeltecLoraV2ESP32/bootloader.bin 0x8000 .pio/build/HeltecLoraV2ESP32/partitions.bin 0x10000 .pio/build/HeltecLoraV2ESP32/firmware.bin 0x210000 .pio/build/HeltecLoraV2ESP32/littlefs.bin
+
+      - name: Prepare firmware and littlefs files for release
+        run: |
+          mv .pio/build/LilyGoLoraESP32/firmware.bin LilyGoLoraESP32_firmware.bin
+          mv .pio/build/LilyGoLoraESP32/littlefs.bin LilyGoLoraESP32_filesystem.bin
+          mv .pio/build/HeltecLoraV2ESP32/firmware.bin HeltecLoraV2ESP32_firmware.bin
+          mv .pio/build/HeltecLoraV2ESP32/littlefs.bin HeltecLoraV2ESP32_filesystem.bin
 
       - name: "✏️ Generate release changelog"
         uses: janheinrichmerker/action-github-changelog-generator@v2.4
@@ -62,7 +69,11 @@ jobs:
           tag_name: ${{ steps.generate_release_tag.outputs.release_tag }}
           files: |
             LilyGoLoraESP32.bin
+            LilyGoLoraESP32_firmware.bin
+            LilyGoLoraESP32_filesystem.bin
             HeltecLoraV2ESP32.bin
+            HeltecLoraV2ESP32_firmware.bin
+            HeltecLoraV2ESP32_filesystem.bin
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
@@ -70,5 +81,9 @@ jobs:
          name: build-artifacts
          path: |
            LilyGoLoraESP32.bin
+           LilyGoLoraESP32_firmware.bin
+           LilyGoLoraESP32_filesystem.bin
            HeltecLoraV2ESP32.bin
+           HeltecLoraV2ESP32_firmware.bin
+           HeltecLoraV2ESP32_filesystem.bin
            changelog.md

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -3,9 +3,10 @@ name: Build and Release
 on:
   workflow_dispatch:
   push:
-    # run on every branch
     branches:
-      - 'main'
+      - master
+    tags:
+      - 'v*'
 
 jobs:
   build-and-release:
@@ -19,6 +20,13 @@ jobs:
 
       - name: Setup PlatformIO
         uses: n-vr/setup-platformio-action@v1
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: ~/.platformio
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
+          restore-keys: ${{ runner.os }}-pio-
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -35,10 +43,10 @@ jobs:
         run: pio run -t buildfs
 
       - name: Merge bin files together for LilyGoLoraESP32
-        run: esptool --chip esp32s3 merge-bin -o LilyGoLoraESP32.bin --flash-size 4MB 0x1000 .pio/build/LilyGoLoraESP32/bootloader.bin 0x8000 .pio/build/LilyGoLoraESP32/partitions.bin 0x10000 .pio/build/LilyGoLoraESP32/firmware.bin 0x210000 .pio/build/LilyGoLoraESP32/littlefs.bin
+        run: esptool --chip esp32 merge-bin -o LilyGoLoraESP32.bin --flash-size 4MB 0x1000 .pio/build/LilyGoLoraESP32/bootloader.bin 0x8000 .pio/build/LilyGoLoraESP32/partitions.bin 0x10000 .pio/build/LilyGoLoraESP32/firmware.bin 0x210000 .pio/build/LilyGoLoraESP32/littlefs.bin
 
       - name: Merge bin files together for HeltecLoraV2ESP32
-        run: esptool --chip esp32s3 merge-bin -o HeltecLoraV2ESP32.bin --flash-size 8MB 0x1000 .pio/build/HeltecLoraV2ESP32/bootloader.bin 0x8000 .pio/build/HeltecLoraV2ESP32/partitions.bin 0x10000 .pio/build/HeltecLoraV2ESP32/firmware.bin 0x210000 .pio/build/HeltecLoraV2ESP32/littlefs.bin
+        run: esptool --chip esp32 merge-bin -o HeltecLoraV2ESP32.bin --flash-size 8MB 0x1000 .pio/build/HeltecLoraV2ESP32/bootloader.bin 0x8000 .pio/build/HeltecLoraV2ESP32/partitions.bin 0x10000 .pio/build/HeltecLoraV2ESP32/firmware.bin 0x290000 .pio/build/HeltecLoraV2ESP32/littlefs.bin
 
       - name: Prepare firmware and littlefs files for release
         run: |
@@ -65,7 +73,7 @@ jobs:
         with:
           name: Release ${{ steps.generate_release_tag.outputs.release_tag }}
           body_path: changelog.md
-          prerelease: github.ref != 'refs/heads/main'
+          prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
           tag_name: ${{ steps.generate_release_tag.outputs.release_tag }}
           files: |
             LilyGoLoraESP32.bin

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 ; > pio project config
 
 [platformio]
-default_envs = HeltecLoraV2ESP32
+default_envs = HeltecLoraV2ESP32, LilyGoLoraESP32
 name = iownhcESP32
 description = io-homecontrol for the ESP32
 data_dir = ./extras


### PR DESCRIPTION
This PR creates a Github Action flow that generates releases from every commit on main.
This makes uploading the new code to the boards easier. Can be done using espwebtools, ...

So the bin files contains bootloader, littlefs, firmware and partitions. Backup of the settings is required before uploading the release files.

Tested the bin file for LilyGoLoraESP32 and works.