### PR TITLE
Improvements in memory usage and concurrency

### DIFF
--- a/include/TickerUsESP32.h
+++ b/include/TickerUsESP32.h
@@ -28,76 +28,81 @@ void system_timer_reinit();
 
 namespace TimersUS {
     class TickerUsESP32 {
-    public:
-    TickerUsESP32();
-    ~TickerUsESP32();
-    typedef void (*callback_t)();
-    typedef void (*callback_with_arg_t)(void*);
+        public:
+            TickerUsESP32();
+            ~TickerUsESP32();
+            typedef void (*callback_t)();
+            typedef void (*callback_with_arg_t)(void*);
 
-    void setMaxIterations(uint32_t maxIterations) {
-        _maxIterations = maxIterations;
-    }
+            void setMaxIterations(uint32_t maxIterations) {
+                _maxIterations = maxIterations;
+            }
 
-    void attach(uint32_t seconds, callback_t callback) {
-        _attach_ms(seconds * 1000, true, reinterpret_cast<callback_with_arg_t>(callback), 0);
-    }
-    void attach_ms(uint32_t milliseconds, callback_t callback) {
-        _attach_ms(milliseconds, true, reinterpret_cast<callback_with_arg_t>(callback), 0);
-    }
-    // Added delayed task
-    void delay_ms(uint32_t milliseconds, callback_t callback) {
-        _delay_ms(milliseconds, false, reinterpret_cast<callback_with_arg_t>(callback), 0);
-    }
-    // Added as uS
-    void attach_us(uint64_t microseconds, callback_t callback) {
-        _attach_us(microseconds, true, reinterpret_cast<callback_with_arg_t>(callback), 0);
-    }
-    template<typename TArg>
-    void attach(uint32_t seconds, void (*callback)(TArg), TArg arg) {
-        static_assert(sizeof(TArg) <= sizeof(uint32_t), "attach() callback argument size must be <= 4 bytes");
-        // C-cast serves two purposes:
-        // static_cast for smaller integer types,
-        // reinterpret_cast + const_cast for pointer types
-        auto arg32 = (uint32_t)arg;
-        _attach_ms(seconds * 1000, true, reinterpret_cast<callback_with_arg_t>(callback), arg32);
-    }
-    template<typename TArg>
-    void attach_ms(uint32_t milliseconds, void (*callback)(TArg), TArg arg) {
-        static_assert(sizeof(TArg) <= sizeof(uint32_t), "attach_ms() callback argument size must be <= 4 bytes");
-        auto arg32 = (uint32_t)arg;
-        _attach_ms(milliseconds, true, reinterpret_cast<callback_with_arg_t>(callback), arg32);
-    }
-    // Added delayed task
-    template<typename TArg>
-    void delay_ms(uint32_t milliseconds, void (*callback)(TArg), TArg arg) {
-        static_assert(sizeof(TArg) <= sizeof(uint32_t), "delay_ms() callback argument size must be <= 4 bytes");
-        auto arg32 = (uint32_t)arg;
-        _delay_ms(milliseconds, false, reinterpret_cast<callback_with_arg_t>(callback), arg32);
-    }
-    // Added as uS
-    template<typename TArg>
-    void attach_us(uint64_t microseconds, void (*callback)(TArg), TArg arg) {
-        static_assert(sizeof(TArg) <= sizeof(uint32_t), "attach_us() callback argument size must be <= 4 bytes");
-        auto arg32 = (uint32_t)arg;
-        _attach_us(microseconds, true, reinterpret_cast<callback_with_arg_t>(callback), arg32);
-    }
+            void attach(uint32_t seconds, callback_t callback) {
+                _attach_ms(seconds * 1000, true, reinterpret_cast<callback_with_arg_t>(callback), 0);
+            }
+            void attach_ms(uint32_t milliseconds, callback_t callback) {
+                _attach_ms(milliseconds, true, reinterpret_cast<callback_with_arg_t>(callback), 0);
+            }
+            // Added delayed task
+            void delay_ms(uint32_t milliseconds, callback_t callback) {
+                _delay_ms(milliseconds, false, reinterpret_cast<callback_with_arg_t>(callback), 0);
+            }
+            // Added as uS
+            void attach_us(uint64_t microseconds, callback_t callback) {
+                _attach_us(microseconds, true, reinterpret_cast<callback_with_arg_t>(callback), 0);
+            }
+            template<typename TArg>
+            void attach(uint32_t seconds, void (*callback)(TArg), TArg arg) {
+                static_assert(sizeof(TArg) <= sizeof(uint32_t), "attach() callback argument size must be <= 4 bytes");
+                // C-cast serves two purposes:
+                // static_cast for smaller integer types,
+                // reinterpret_cast + const_cast for pointer types
+                auto arg32 = (uint32_t)arg;
+                _attach_ms(seconds * 1000, true, reinterpret_cast<callback_with_arg_t>(callback), arg32);
+            }
+            template<typename TArg>
+            void attach_ms(uint32_t milliseconds, void (*callback)(TArg), TArg arg) {
+                static_assert(sizeof(TArg) <= sizeof(uint32_t), "attach_ms() callback argument size must be <= 4 bytes");
+                auto arg32 = (uint32_t)arg;
+                _attach_ms(milliseconds, true, reinterpret_cast<callback_with_arg_t>(callback), arg32);
+            }
+            // Added delayed task
+            template<typename TArg>
+            void delay_ms(uint32_t milliseconds, void (*callback)(TArg), TArg arg) {
+                static_assert(sizeof(TArg) <= sizeof(uint32_t), "delay_ms() callback argument size must be <= 4 bytes");
+                auto arg32 = (uint32_t)arg;
+                _delay_ms(milliseconds, false, reinterpret_cast<callback_with_arg_t>(callback), arg32);
+            }
+            // Added as uS
+            template<typename TArg>
+            void attach_us(uint64_t microseconds, void (*callback)(TArg), TArg arg) {
+                static_assert(sizeof(TArg) <= sizeof(uint32_t), "attach_us() callback argument size must be <= 4 bytes");
+                auto arg32 = (uint32_t)arg;
+                _attach_us(microseconds, true, reinterpret_cast<callback_with_arg_t>(callback), arg32);
+            }
 
-    void detach();
-    bool active();
+            void detach();
+            bool active();
 
-    private:
-        uint32_t _iterationCount = 0;
-        uint32_t _maxIterations = UINT32_MAX;  // Par défaut, pas de limite d'itérations
+            uint32_t currentTimerMicros() { return active() ? _currentTimerMicros : -1; }
+            uint32_t currentTimerMillis() { return active() ? _currentTimerMicros / 1000 : -1; }
 
-    protected:
-    void _attach_ms(uint32_t milliseconds, bool repeat, callback_with_arg_t callback, uint32_t arg);
-    // Added delayed task
-    void _delay_ms(uint32_t milliseconds, bool repeat, callback_with_arg_t callback, uint32_t arg);
-    // Added as uS
-    void _attach_us(uint64_t microseconds, bool repeat, callback_with_arg_t callback, uint32_t arg);
+        private:
+            uint32_t _iterationCount = 0;
+            uint32_t _maxIterations = UINT32_MAX;  // Par défaut, pas de limite d'itérations
 
-    esp_timer_handle_t _timer;
-    esp_timer_handle_t _timer_delayed{};
+            uint32_t _currentTimerMicros = 0;
+
+        protected:
+            void _attach_ms(uint32_t milliseconds, bool repeat, callback_with_arg_t callback, uint32_t arg);
+            // Added delayed task
+            void _delay_ms(uint32_t milliseconds, bool repeat, callback_with_arg_t callback, uint32_t arg);
+            // Added as uS
+            void _attach_us(uint64_t microseconds, bool repeat, callback_with_arg_t callback, uint32_t arg);
+
+            esp_timer_handle_t _timer;
+            esp_timer_handle_t _timer_delayed{};
     };
 }
 

--- a/include/interact.h
+++ b/include/interact.h
@@ -22,6 +22,7 @@
 #include <board-config.h>
 #include <user_config.h>
 
+#include <atomic>
 #include <vector>
 #include <sstream>
 #include <cstring>
@@ -80,9 +81,9 @@ extern uint8_t lastEntry;
 
 namespace Cmd {
 
-extern bool verbosity;
-extern bool pairMode;
-extern bool scanMode;
+extern std::atomic<bool> verbosity;
+extern std::atomic<bool> pairMode;
+extern std::atomic<bool> scanMode;
 
 #if defined(ESP32)
   extern TimersUS::TickerUsESP32 kbd_tick;

--- a/include/iohcCozyDevice2W.h
+++ b/include/iohcCozyDevice2W.h
@@ -84,7 +84,6 @@ namespace IOHC {
         };
 
         std::vector<device> devices;
-        std::vector<iohcPacket *> packets2send{};
     };
 }
 #endif

--- a/include/iohcDevice.h
+++ b/include/iohcDevice.h
@@ -66,7 +66,6 @@ namespace IOHC {
         bool Fake = false;
         bool Home = false;
 
-        std::vector<iohcPacket *> packets2send{};
         iohcRadio *_radioInstance{};
     };
 }

--- a/include/iohcOtherDevice2W.h
+++ b/include/iohcOtherDevice2W.h
@@ -84,9 +84,6 @@ namespace IOHC {
         //            std::vector<uint16_t> _type;
         //            uint8_t _manufacturer;
 
-        //            IOHC::iohcPacket *packets2send[2]; //[25];
-        // std::array<iohcPacket*, 25> packets2send{};
-        std::vector<iohcPacket *> packets2send{};
         //            IOHC::iohcRadio *_radioInstance;
     };
 }

--- a/include/iohcPacket.h
+++ b/include/iohcPacket.h
@@ -17,6 +17,7 @@
 #ifndef IOHC_PACKET_H
 #define IOHC_PACKET_H
 
+#include <atomic>
 #include <vector>
 #include <string>
 
@@ -33,6 +34,12 @@
 
 namespace IOHC {
     typedef uint8_t address[3];
+
+    struct Address3 {
+        uint8_t b[3] = {0};
+        uint8_t _pad = 0;  // pad to 4 bytes for lock-free atomic on Xtensa ESP32
+        bool operator==(const Address3 &o) const { return b[0]==o.b[0] && b[1]==o.b[1] && b[2]==o.b[2]; }
+    };
 
     struct CB1 {
         uint8_t MsgLen: 5; //1
@@ -205,10 +212,10 @@ namespace IOHC {
         std::vector<uint8_t> memorizedData;
     } Memorize;
 
-    inline unsigned long packetStamp = 0L;
-    inline unsigned long relStamp = 0L;
-    inline size_t lastSendCmd = 0xFF;
-    inline address lastFromAddress = {0};
+    inline std::atomic<unsigned long> packetStamp = 0L;
+    inline std::atomic<unsigned long> relStamp = 0L;
+    inline std::atomic<size_t> lastSendCmd = 0xFF;
+    inline std::atomic<Address3> lastFromAddress = {};
     /**
     Class implementing the IOHC packet received/sent, including some additional members useful to track/control Radio parameters and timings
     */

--- a/include/iohcRadio.h
+++ b/include/iohcRadio.h
@@ -85,8 +85,8 @@ namespace IOHC {
             static iohcRadio *_iohcRadio;
             static uint8_t _flags[2];
 
-            volatile uint32_t tickCounter = 0;
-            volatile uint32_t preCounter = 0;
+            std::atomic<uint32_t> tickCounter = 0;
+            std::atomic<uint32_t> preCounter = 0;
             void transmitPacket(uint16_t preambleLen, iohcPacket *iohc);
             static void IRAM_ATTR onTxTicker(void *arg);
 

--- a/include/iohcRadio.h
+++ b/include/iohcRadio.h
@@ -20,6 +20,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+#include <atomic>
 #include <Delegate.h>
 #include <cstdint>
 #include <queue>
@@ -67,13 +68,11 @@ namespace IOHC {
             void start(uint8_t num_freqs, uint32_t *scan_freqs, uint32_t scanTimeUs, IohcPacketDelegate rxCallback, IohcPacketDelegate txCallback);
             void send(iohcPacket *packet);
             void send(std::vector<iohcPacket*>&iohcTx);
-            void sendAuto(std::vector<iohcPacket*>&iohcTx); // Nieuwe versie voor AutoTxRx
             static void setRadioState(RadioState newState);
             static const char* radioStateToString(RadioState state);
-            volatile static RadioState radioState;
             static void tickerCounter(iohcRadio *radio);
-            static TaskHandle_t txTaskHandle; // TX Task handle
-            static volatile bool txComplete;
+            static std::atomic<RadioState> radioState;
+            static std::atomic<bool> txComplete;
             //static void setPreambleLength(uint16_t preambleLen);
 
         private:
@@ -85,16 +84,10 @@ namespace IOHC {
 
             static iohcRadio *_iohcRadio;
             static uint8_t _flags[2];
-            volatile static unsigned long _g_payload_millis;
-            
-            volatile static bool send_lock;
 
             volatile uint32_t tickCounter = 0;
             volatile uint32_t preCounter = 0;
-            volatile uint8_t txCounter = 0;
-            static void txTaskLoop(void *pvParameters);
-            static void lightTxTask(void *pvParameters);
-            //TaskHandle_t txTaskHandle = nullptr;
+            void transmitPacket(uint16_t preambleLen, iohcPacket *iohc);
             static void IRAM_ATTR onTxTicker(void *arg);
 
             uint8_t num_freqs = 0;
@@ -110,18 +103,16 @@ namespace IOHC {
             TimersUS::TickerUsESP32 TickTimer;
             TimersUS::TickerUsESP32 Sender;
         #endif
-            iohcPacket *iohc{};
-            iohcPacket *delayed{};
             
             IohcPacketDelegate rxCB = nullptr;
             IohcPacketDelegate txCB = nullptr;
-            std::vector<iohcPacket*> packets2send{};
+            std::queue<iohcPacket*> packets2send{};
             std::queue<std::vector<iohcPacket*>> sendQueue{};
+
+            template<typename T>
+            T accessInMutex(std::function<T()> handler);
         protected:
             static void i_preamble();
-            static void i_payload();
-            static void packetSender(iohcRadio *radio);
-            static void configureAutoTxRx(iohcPacket *packet); // Hulpfunctie om AutoTxRx te activeren
 
         #if defined(CC1101)
             uint8_t lenghtFrame=0;

--- a/include/iohcRadio.h
+++ b/include/iohcRadio.h
@@ -65,6 +65,7 @@ namespace IOHC {
                 ERROR        ///< Error or unknown state
             };
             void start(uint8_t num_freqs, uint32_t *scan_freqs, uint32_t scanTimeUs, IohcPacketDelegate rxCallback, IohcPacketDelegate txCallback);
+            void send(iohcPacket *packet);
             void send(std::vector<iohcPacket*>&iohcTx);
             void sendAuto(std::vector<iohcPacket*>&iohcTx); // Nieuwe versie voor AutoTxRx
             static void setRadioState(RadioState newState);

--- a/include/iohcRadio.h
+++ b/include/iohcRadio.h
@@ -87,6 +87,7 @@ namespace IOHC {
 
             std::atomic<uint32_t> tickCounter = 0;
             std::atomic<uint32_t> preCounter = 0;
+            std::atomic<uint64_t> txTimestamp = 0;
             void transmitPacket(uint16_t preambleLen, iohcPacket *iohc);
             static void IRAM_ATTR onTxTicker(void *arg);
 

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -95,9 +95,6 @@ namespace IOHC {
 
 
         std::vector<remote> remotes;
-
-        std::vector<iohcPacket *> packets2send{};
-
     };
 }
 #endif

--- a/include/mqtt_handler.h
+++ b/include/mqtt_handler.h
@@ -18,7 +18,6 @@ extern const char AVAILABILITY_TOPIC[];
 
 void initMqtt();
 void connectToMqtt();
-static void publishIohcFrameDiscovery();
 void onMqttConnect(bool sessionPresent);
 void onMqttDisconnect(AsyncMqttClientDisconnectReason reason);
 void onMqttMessage(char *topic, char *payload,
@@ -33,9 +32,7 @@ void mqttFuncHandler(const char *cmd);
 void publishCoverState(const std::string &id, const char *state);
 void publishCoverPosition(const std::string &id, float position);
 void removeDiscovery(const std::string &id);
-static TaskHandle_t s_mqttPostConnectTask = nullptr;
-static void mqttPostConnectTask(void*);
-static void handleMqttConnectImpl();
+extern TaskHandle_t s_mqttPostConnectTask;
 
 #endif // MQTT
 

--- a/include/oled_display.h
+++ b/include/oled_display.h
@@ -27,6 +27,7 @@ void updateDisplayStatus();
 #else
 inline bool initDisplay() { return true; }
 inline void display1WAction(const uint8_t *, const char *, const char *, const char * = nullptr) {}
+inline void display1WPosition(const uint8_t *, float, const char * = nullptr) {}
 inline void updateDisplayStatus() {}
 #endif
 

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -48,6 +48,9 @@ inline uint16_t syslog_port = 514;     // Syslog server port
 // Comment out the next line to disable the built-in web server
 #define WEBSERVER
 
+// Comment out the next line to lower WiFi security in order to allow connecting to open WiFi networks
+#define REQUIRE_MINIMUM_WPA2_PSK
+
 #define HTTP_LISTEN_PORT    80
 #define HTTP_USERNAME       "admin"
 #define HTTP_PASSWORD       "admin"

--- a/include/wifi_helper.h
+++ b/include/wifi_helper.h
@@ -29,7 +29,6 @@ extern struct WiFiStatus {
 
 
 void initWifi();
-void connectToWifi(TimerHandle_t timer = nullptr);
 void checkWifiConnection();
 
 #endif // WIFI_HELPER_H

--- a/src/TickerUsESP32.cpp
+++ b/src/TickerUsESP32.cpp
@@ -42,6 +42,7 @@ namespace TimersUS {
         _timerConfig.dispatch_method = ESP_TIMER_TASK;
         _timerConfig.skip_unhandled_events = true;//false; //true;
         _timerConfig.name = "TickerMsESP32";
+        _currentTimerMicros = milliseconds * 1000;
         if (_timer) {
             ESP_ERROR_CHECK(esp_timer_stop(_timer));
             ESP_ERROR_CHECK(esp_timer_delete(_timer));
@@ -67,6 +68,7 @@ namespace TimersUS {
         _timerConfig.dispatch_method = ESP_TIMER_TASK;
         //    _timerConfig.skip_unhandled_events = true;
         _timerConfig.name = "TickerMsESP32Delay";
+        _currentTimerMicros = milliseconds * 1000;
         if (_timer_delayed) {
             ESP_ERROR_CHECK(esp_timer_delete(_timer_delayed));
         }
@@ -84,7 +86,8 @@ namespace TimersUS {
         _timerConfig.dispatch_method = ESP_TIMER_TASK;
         _timerConfig.skip_unhandled_events = true;
         _timerConfig.name = "TickerUsESP32";
-
+        _currentTimerMicros = microseconds;
+        
         if (_timer) {
             ESP_ERROR_CHECK(esp_timer_stop(_timer));
             ESP_ERROR_CHECK(esp_timer_delete(_timer));

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -46,17 +46,17 @@ void tokenize(std::string const &str, const char delim, Tokens &out) {
 
 
 namespace Cmd {
-bool verbosity = true;
-bool pairMode = false;
-bool scanMode = false;
+std::atomic<bool> verbosity = true;
+std::atomic<bool> pairMode = false;
+std::atomic<bool> scanMode = false;
 #if defined(ESP32)
 TimersUS::TickerUsESP32 kbd_tick;
 #endif
 TimerHandle_t consoleTimer;
 
 static char _rxbuffer[512];
-static uint8_t _len = 0;
-static uint8_t _avail = 0;
+static uint16_t _len = 0;
+static uint16_t _avail = 0;
 /**
  * The function `createCommands()` initializes and adds various command handlers for controlling
  * different devices and functionalities.
@@ -308,7 +308,8 @@ void createCommands() {
     Cmd::addHandler((char *) "cat", (char *) "Print file content", [](Tokens *cmd)-> void { cat(cmd->at(1).c_str()); });
     Cmd::addHandler((char *) "rm", (char *) "Remove file", [](Tokens *cmd)-> void { rm(cmd->at(1).c_str()); });
     Cmd::addHandler((char *) "lastAddr", (char *) "Show last received address", [](Tokens *cmd)-> void {
-        Serial.println(bytesToHexString(IOHC::lastFromAddress, sizeof(IOHC::lastFromAddress)).c_str());
+        const auto _a = IOHC::lastFromAddress.load();
+        Serial.println(bytesToHexString(_a.b, sizeof(_a.b)).c_str());
     });
 #if defined(MQTT)
     Cmd::addHandler((char *) "mqttIp", (char *) "Set MQTT server IP", [](Tokens *cmd)-> void {
@@ -481,6 +482,10 @@ bool addHandler(char *cmd, char *description, void (*handler)(Tokens*)) {
 char *cmdReceived(bool echo) {
   _avail = Serial.available();
   if (_avail) {
+    if ((_len + _avail) > 512) {
+        _avail = 512 - _len;
+        Serial.println("Too much data, truncating it at 512 bytes");
+    }
     _len += Serial.readBytes(&_rxbuffer[_len], _avail);
     if (echo) {
       _rxbuffer[_len] = '\0';

--- a/src/iohcCozyDevice2W.cpp
+++ b/src/iohcCozyDevice2W.cpp
@@ -287,8 +287,15 @@ namespace IOHC {
 
         fs::File f = LittleFS.open(COZY_2W_FILE, "r", true);
         JsonDocument doc;
-        deserializeJson(doc, f);
+        DeserializationError error = deserializeJson(doc, f);
         f.close();
+
+        if (error) {
+            Serial.print("Failed to parse JSON: ");
+            Serial.println(error.c_str());
+            return false;
+        }
+
 
         // Iterate through the JSON object
         for (JsonPair kv: doc.as<JsonObject>()) {

--- a/src/iohcCozyDevice2W.cpp
+++ b/src/iohcCozyDevice2W.cpp
@@ -84,7 +84,6 @@ namespace IOHC {
             case DeviceButton::associate: {
                 std::vector<uint8_t> toSend = {};
 
-                packets2send.clear();
                 auto* packet = new iohcPacket;
                 forgePacket(packet, toSend);
 
@@ -98,15 +97,13 @@ namespace IOHC {
                 memcpy(packet->payload.packet.header.source, gateway, 3);
                 memcpy(packet->payload.packet.header.target, master_to, 3);
 
-                packets2send.push_back(packet);
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 break;
             }
             case DeviceButton::powerOn: {
                 std::vector<uint8_t> toSend = {0x0C, 0x60, 0x01, 0x2C};
 
-                packets2send.clear();
                 auto* packet = new iohcPacket;
                 forgePacket(packet, toSend);
 
@@ -119,9 +116,8 @@ namespace IOHC {
                 memcpy(packet->payload.packet.header.source, gateway, 3);
                 memcpy(packet->payload.packet.header.target, master_to, 3);
 
-                packets2send.push_back(packet);
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
 
                 break;
             }
@@ -135,7 +131,6 @@ namespace IOHC {
                 if (data->size() == 2) addr = 0;
                 else addr = std::stoi(data->at(2));
 
-                packets2send.clear();
                 auto* packet = new iohcPacket;
                 forgePacket(packet, toSend);
 
@@ -150,9 +145,8 @@ namespace IOHC {
 
                 packet->delayed = 50;
 
-                packets2send.push_back(packet);
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 //                mqttClient.publish("iown/Frame", 0, false, message.c_str(), messageSize);
 
                 break;
@@ -173,7 +167,7 @@ namespace IOHC {
 
                 size_t dest = 0;
 
-                packets2send.clear();
+                std::vector<iohcPacket *> packets2send;
                 for (const auto &addr: addresses) {
                     packets2send.push_back(new iohcPacket);
                     forgePacket(packets2send.back(), toSend);
@@ -203,21 +197,20 @@ namespace IOHC {
                 if (strcasecmp(dat, "on") == 0) toSend[4] = 0x01;
                 if (strcasecmp(dat, "off") == 0) toSend[4] = 0x00;
 
-                packets2send.clear();
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend);
+                auto* packet = new iohcPacket;
+                forgePacket(packet, toSend);
 
-                packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
+                packet->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
                 memorizeSend.memorizedData = toSend;
                 memorizeSend.memorizedCmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                memcpy(packets2send.back()->payload.packet.header.source, gateway, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, master_to, 3);
+                memcpy(packet->payload.packet.header.source, gateway, 3);
+                memcpy(packet->payload.packet.header.target, master_to, 3);
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 break;
             }
             case DeviceButton::setWindow: {
@@ -231,23 +224,22 @@ namespace IOHC {
                 if (data->size() == 2) addr = 0;
                 else addr = std::stoi(data->at(2));
 
-                packets2send.clear();
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend);
+                auto* packet = new iohcPacket;
+                forgePacket(packet, toSend);
 
-                packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
+                packet->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
                 memorizeSend.memorizedData = toSend;
                 memorizeSend.memorizedCmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                memcpy(packets2send.back()->payload.packet.header.source, gateway, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, addresses.at(addr).data()/* 0 Master_to*/, 3);
+                memcpy(packet->payload.packet.header.source, gateway, 3);
+                memcpy(packet->payload.packet.header.target, addresses.at(addr).data()/* 0 Master_to*/, 3);
 
-                packets2send.back()->delayed = 50;
+                packet->delayed = 50;
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 break;
             }
             case DeviceButton::midnight: {
@@ -255,21 +247,20 @@ namespace IOHC {
                 std::vector<uint8_t> toSend = {0x0c, 0x60, 0x01, 0x30};
                 //, 0x2b, 0x05, 0x00, 0x0f, 0x04, 0x0c, 0xe7, 0x07};
 
-                packets2send.clear();
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend);
+                auto *packet = new iohcPacket;
+                forgePacket(packet, toSend);
 
-                packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
+                packet->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
                 memorizeSend.memorizedData = toSend;
                 memorizeSend.memorizedCmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                memcpy(packets2send.back()->payload.packet.header.source, gateway, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, master_to, 3);
+                memcpy(packet->payload.packet.header.source, gateway, 3);
+                memcpy(packet->payload.packet.header.target, master_to, 3);
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
 
                 break;
             }

--- a/src/iohcOtherDevice2W.cpp
+++ b/src/iohcOtherDevice2W.cpp
@@ -75,23 +75,24 @@ namespace IOHC {
             Serial.println("NO RADIO INSTANCE");
             _radioInstance = iohcRadio::getInstance();
         }
-        packets2send.clear();
 
         // Emulates device button press
         switch (cmd) {
             case Other2WButton::discovery: {
                 int bec = 0;
 
+                std::vector<iohcPacket *> packets2send;
                 for (int j = 0; j < 255; j++) {
-                    packets2send.push_back(new iohcPacket);
+                    auto *packet = new iohcPacket;
+                    packets2send.push_back(packet);
 
                     std::string discovery = "d430477706ba11ad31"; //28"; //"2b578ebc37334d6e2f50a4dfa9";
                     std::vector<uint8_t> toSend = {};
-                    packets2send.back()->buffer_length = hexStringToBytes(
-                        discovery, packets2send.back()/*[j]*/->payload.buffer);
-                    forgePacket(packets2send.back()/*[j]*//*->payload.buffer[4]*/, toSend, bec);
+                    packet->buffer_length = hexStringToBytes(
+                        discovery, packet/*[j]*/->payload.buffer);
+                    forgePacket(packet/*[j]*//*->payload.buffer[4]*/, toSend, bec);
                     bec += 0x01;
-                    packets2send.back()->repeatTime = 250; // Slow down discovery loop
+                    packet->repeatTime = 250; // Slow down discovery loop
                 }
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
@@ -112,30 +113,31 @@ namespace IOHC {
                 // uint8_t target[3] = {0x08, 0x42, 0xE3};
                 // toSend[3] = custom;
 
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend, 0);
-                packets2send.back()->payload.packet.header.cmd = SEND_GET_NAME_0x50;
+                auto *packet = new iohcPacket;
+                forgePacket(packet, toSend, 0);
+                packet->payload.packet.header.cmd = SEND_GET_NAME_0x50;
                 // memorizeSend.memorizedData = toSend;
                 // memorizeSend.memorizedCmd = SEND_WRITE_PRIVATE_0x20;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
-//                packets2send.back()->payload.packet.header.CtrlByte1.asByte += toSend.size();
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+//                packet->payload.packet.header.CtrlByte1.asByte += toSend.size();
 
-                memcpy(packets2send.back()->payload.packet.header.source, fake_gateway, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, target, 3);
+                memcpy(packet->payload.packet.header.source, fake_gateway, 3);
+                memcpy(packet->payload.packet.header.target, target, 3);
 
-//                memcpy(packets2send.back()->payload.buffer + 9, toSend.data(), toSend.size());
-//                packets2send.back()->buffer_length = toSend.size() + 9;
+//                memcpy(packet->payload.buffer + 9, toSend.data(), toSend.size());
+//                packet->buffer_length = toSend.size() + 9;
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                // packets2send.back()->delayed = 501;
-                _radioInstance->send(packets2send);
+                // packet->delayed = 501;
+                _radioInstance->send(packet);
                 break;
             }
             case Other2WButton::custom: {
                 std::vector<uint8_t> toSend = {0x01, 0x47, 0xc8, 0x00, 0x00, 0x00};
                 //{0x03, 0x65, 0xd4, 0x00, 0x00, 0x00}; //{0x0C, 0x60, 0x01, 0xFF, 0xFF};
                 //const char* dat = data->at(1).c_str();
+                std::vector<iohcPacket *> packets2send;
                 for (int acei = 0; acei < 256; acei++) {
                     //               int custom = std::stoi(data->at(1));
                     AceiUnion ACEI{};
@@ -150,23 +152,23 @@ namespace IOHC {
                     address to = {0xda, 0x2e, 0xe6}; //
                     address to_1 = {0x05, 0x4e, 0x17}; //{0x31, 0x58, 0x24}; //
 
-//                    packets2send.clear();
-                    packets2send.push_back(new iohcPacket);
-                    forgePacket(packets2send.back(), toSend);
+                    auto *packet = new iohcPacket;
+                    packets2send.push_back(packet);
+                    forgePacket(packet, toSend);
 
-                    packets2send.back()->payload.packet.header.cmd = 0x00; //SEND_WRITE_PRIVATE_0x20;
+                    packet->payload.packet.header.cmd = 0x00; //SEND_WRITE_PRIVATE_0x20;
                     memorizeOther2W.memorizedData = toSend;
                     memorizeOther2W.memorizedCmd = 0x00; //SEND_WRITE_PRIVATE_0x20;
 
-                    packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
 
-                    memcpy(packets2send.back()->payload.packet.header.source, from/*gateway*/, 3);
-                    memcpy(packets2send.back()->payload.packet.header.target, to_1, 3);
+                    memcpy(packet->payload.packet.header.source, from/*gateway*/, 3);
+                    memcpy(packet->payload.packet.header.target, to_1, 3);
 
-                    packets2send.back()->delayed = 250; // Give enough time for the answer
+                    packet->delayed = 250; // Give enough time for the answer
                 }
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
                 _radioInstance->send(packets2send);
@@ -182,25 +184,24 @@ namespace IOHC {
 
                 toSend[3] = custom; //custom;
 
-//                packets2send.clear();
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend);
+                auto *packet = new iohcPacket;
+                forgePacket(packet, toSend);
 
-                packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
+                packet->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
                 memorizeOther2W.memorizedData = toSend;
                 memorizeOther2W.memorizedCmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                // packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                // packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
+                // packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                // packet->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
 
-                memcpy(packets2send.back()->payload.packet.header.source, gateway/*master_from*/, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, master_to/*slave_to*/, 3);
+                memcpy(packet->payload.packet.header.source, gateway/*master_from*/, 3);
+                memcpy(packet->payload.packet.header.target, master_to/*slave_to*/, 3);
 
-                packets2send.back()->delayed = 250;
+                packet->delayed = 250;
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 break;
             }
             case Other2WButton::discover28: {
@@ -209,26 +210,27 @@ namespace IOHC {
                 //                uint8_t broadcast[3];
                 address broadcast = {0x00, 0xFF, 0xFB}; //{0x02, 0x02, 0xFB}; //data->at(1).c_str();
                 //            hexStringToBytes(dat, broadcast);
-//                packets2send.clear();
                 size_t i = 0;
+                std::vector<iohcPacket *> packets2send;
                 for (i = 0; i < 10; i++) {
-                    packets2send.push_back(new iohcPacket);
-                    forgePacket(packets2send[i], toSend);
+                    auto *packet = new iohcPacket;
+                    packets2send.push_back(packet);
+                    forgePacket(packet, toSend);
 
-                    packets2send[i]->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_0x28;
+                    packet->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_0x28;
                     memorizeOther2W.memorizedData = toSend;
                     memorizeOther2W.memorizedCmd = iohcDevice::SEND_DISCOVER_0x28;
 
-                    packets2send[i]->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
-                    packets2send[i]->payload.packet.header.CtrlByte1.asStruct.EndFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.EndFrame = 1;
 
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
 
-                    memcpy(packets2send[i]->payload.packet.header.source, gateway, 3);
-                    memcpy(packets2send[i]->payload.packet.header.target, broadcast, 3);
+                    memcpy(packet->payload.packet.header.source, gateway, 3);
+                    memcpy(packet->payload.packet.header.target, broadcast, 3);
 
-                    packets2send[i]->delayed = 250; // Give enough time for the answer
+                    packet->delayed = 250; // Give enough time for the answer
                 }
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
                 _radioInstance->send(packets2send);
@@ -253,21 +255,22 @@ namespace IOHC {
                 address broadcast_3b = {0x00, 0x00, 0x3b};
                 address broadcast_3f = {0x00, 0x00, 0x3f};
 
-//                packets2send.clear();
+                std::vector<iohcPacket *> packets2send;
                 for (size_t i = 0; i < 2; i++) {
-                    packets2send.push_back(new iohcPacket);
+                    auto *packet = new iohcPacket;
+                    packets2send.push_back(packet);
 
                     if (i > 20) {
                         std::vector<uint8_t> toSend = {0x00};
-                        forgePacket(packets2send.back(), toSend);
-                        packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_UNKNOWN_0x2E;
-                        memcpy(packets2send.back()->payload.packet.header.target, broadcast_3f, 3);
+                        forgePacket(packet, toSend);
+                        packet->payload.packet.header.cmd = iohcDevice::SEND_UNKNOWN_0x2E;
+                        memcpy(packet->payload.packet.header.target, broadcast_3f, 3);
                     }
                     if (i <= 20) {
                         std::vector<uint8_t> toSend = {};
-                        forgePacket(packets2send.back(), toSend);
-                        packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_0x28;
-                        memcpy(packets2send.back()->payload.packet.header.target, broadcast_3b, 3);
+                        forgePacket(packet, toSend);
+                        packet->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_0x28;
+                        memcpy(packet->payload.packet.header.target, broadcast_3b, 3);
                     }
                     if (i <= 10) {
                         std::vector<uint8_t> toSend = {
@@ -276,25 +279,25 @@ namespace IOHC {
                         std::vector<uint8_t> toSend2 = {
                             0xa0, 0xb4, 0x38, 0xd2, 0x5f, 0x27, 0x28, 0x6f, 0xed, 0xd2, 0xad, 0x1f
                         };
-                        forgePacket(packets2send.back(), toSend2);
-                        packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_REMOTE_0x2A;
-                        memcpy(packets2send.back()->payload.packet.header.target, broadcast_3b, 3);
+                        forgePacket(packet, toSend2);
+                        packet->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_REMOTE_0x2A;
+                        memcpy(packet->payload.packet.header.target, broadcast_3b, 3);
                     }
-                    //                    packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_REMOTE_0x2A;
+                    //                    packet->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_REMOTE_0x2A;
 
                     //                    memorizeSend.memorizedData = toSend; //.assign(toSend, toSend + 12);
                     //                    memorizeSend.memorizedCmd = iohcDevice::SEND_DISCOVER_REMOTE_0x2A;
 
-                    packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
-                    packets2send.back()->payload.packet.header.CtrlByte1.asStruct.EndFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.EndFrame = 1;
 
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
 
-                    memcpy(packets2send.back()->payload.packet.header.source, /*from*/realcopy/*gateway*/, 3);
+                    memcpy(packet->payload.packet.header.source, /*from*/realcopy/*gateway*/, 3);
 
-                    packets2send.back()->delayed = 250; // Give enough time for the answer
-                    packets2send.back()->repeatTime = 250; // Slow down discover loop
+                    packet->delayed = 250; // Give enough time for the answer
+                    packet->repeatTime = 250; // Slow down discover loop
                 }
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 
@@ -320,27 +323,28 @@ namespace IOHC {
                     {0x47, 0x77, 0x06}, {0x48, 0x79, 0x02}, {0x8C, 0xCB, 0x30}, {0x8C, 0xCB, 0x31}
                 };
 
-//                packets2send.clear();
                 size_t i = 0;
+                std::vector<iohcPacket *> packets2send;
                 for (i = 0; i < 15; i++) {
-                    packets2send.push_back(new iohcPacket);
-                    forgePacket(packets2send.back(), toSend);
+                    auto *packet = new iohcPacket;
+                    packets2send.push_back(packet);
+                    forgePacket(packet, toSend);
 
-                    packets2send.back()->payload.packet.header.cmd = 0x00;
+                    packet->payload.packet.header.cmd = 0x00;
                     memorizeOther2W.memorizedData = toSend;
                     memorizeOther2W.memorizedCmd = 0x00;
                     IOHC::lastSendCmd = 0x00;
 
-                    packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                    // packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Unk1 = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                    // packet->payload.packet.header.CtrlByte2.asStruct.Unk1 = 1;
 
-                    memcpy(packets2send.back()->payload.packet.header.source, from/*gateway*/, 3);
-                    memcpy(packets2send.back()->payload.packet.header.target, guessed[i], 3);
+                    memcpy(packet->payload.packet.header.source, from/*gateway*/, 3);
+                    memcpy(packet->payload.packet.header.target, guessed[i], 3);
 
-                    packets2send.back()->delayed = 250; // Give enough time for the answer
-                    packets2send.back()->repeatTime = 250; // Slow down discover loop
+                    packet->delayed = 250; // Give enough time for the answer
+                    packet->repeatTime = 250; // Slow down discover loop
                 }
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
                 _radioInstance->send(packets2send);
@@ -350,21 +354,20 @@ namespace IOHC {
             case Other2WButton::ack: {
                 std::vector<uint8_t> toSend = {};
 
-//                packets2send.clear();
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend);
+                auto *packet = new iohcPacket;
+                forgePacket(packet, toSend);
 
-                packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_KEY_TRANSFERT_ACK_0x33;
+                packet->payload.packet.header.cmd = iohcDevice::SEND_KEY_TRANSFERT_ACK_0x33;
                 memorizeOther2W.memorizedCmd = iohcDevice::SEND_KEY_TRANSFERT_ACK_0x33;
                 memorizeOther2W.memorizedData = toSend;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                memcpy(packets2send.back()->payload.packet.header.source, gateway, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, master_from, 3);
+                memcpy(packet->payload.packet.header.source, gateway, 3);
+                memcpy(packet->payload.packet.header.target, master_from, 3);
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 break;
             }
             case Other2WButton::checkCmd: {
@@ -388,7 +391,7 @@ namespace IOHC {
                 address broad = {0x00, 0x0d, 0x3b}; //{0x00, 0xFF, 0xFB}; //
 
                 uint8_t counter = 0;
-//                packets2send.clear();
+                std::vector<iohcPacket *> packets2send;
                 for (const auto &command: mapValid) {
                     if (command.second == 0 || (command.second == 5 && command.first != 0x19)) {
                         counter++;
@@ -426,26 +429,27 @@ namespace IOHC {
                         if (command.first == 0x60 || command.first == 0x82)
                             toSend.assign(special12, special12 + 21);
 
-                        packets2send.push_back(new iohcPacket);
-                        forgePacket(packets2send.back(), toSend);
-                        packets2send.back()->payload.packet.header.cmd = command.first;
-                        memorizeOther2W.memorizedCmd = packets2send.back()->payload.packet.header.cmd;
+                        auto *packet = new iohcPacket;
+                        packets2send.push_back(packet);
+                        forgePacket(packet, toSend);
+                        packet->payload.packet.header.cmd = command.first;
+                        memorizeOther2W.memorizedCmd = packet->payload.packet.header.cmd;
 
-                        packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
-                        packets2send.back()->payload.packet.header.CtrlByte1.asStruct.EndFrame = 0;
-                        packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                        packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
+                        packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                        packet->payload.packet.header.CtrlByte1.asStruct.EndFrame = 0;
+                        packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                        packet->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
 
-                        memcpy(packets2send.back()->payload.packet.header.source, gateway/*from*//*gateway*/, 3);
+                        memcpy(packet->payload.packet.header.source, gateway/*from*//*gateway*/, 3);
                         // if (command.first == 0x14 || command.first == 0x19 || command.first == 0x1e || command.first == 0x2a || command.first == 0x34 || command.first == 0x4a) {
-                        // memcpy(packets2send.back()->payload.packet.header.target, broad, 3);
+                        // memcpy(packet->payload.packet.header.target, broad, 3);
                         // } else {
-                        memcpy(packets2send.back()->payload.packet.header.target, master_to, 3);
+                        memcpy(packet->payload.packet.header.target, master_to, 3);
                         // }
 
-                        //packets2send.back()->delayed = 245;
-                        packets2send.back()->repeatTime = 250; // Slow down discover loop
-                        packets2send.back()->delayed = 250;   // Give enough time for the answer
+                        //packet->delayed = 245;
+                        packet->repeatTime = 250; // Slow down discover loop
+                        packet->delayed = 250;   // Give enough time for the answer
                     }
                     toSend.clear();
                 }

--- a/src/iohcOtherDevice2W.cpp
+++ b/src/iohcOtherDevice2W.cpp
@@ -537,8 +537,14 @@ namespace IOHC {
 
         fs::File f = LittleFS.open(OTHER_2W_FILE, "r", true);
         JsonDocument doc;
-        deserializeJson(doc, f);
+        DeserializationError error = deserializeJson(doc, f);
         f.close();
+
+        if (error) {
+            Serial.print("Failed to parse JSON: ");
+            Serial.println(error.c_str());
+            return false;
+        }
 
         // Iterate through the JSON object
         for (JsonPair kv: doc.as<JsonObject>()) {

--- a/src/iohcPacket.cpp
+++ b/src/iohcPacket.cpp
@@ -27,7 +27,7 @@ namespace IOHC {
 
         if (packetStamp - relStamp > 500000L) {
             printf("\n");
-            relStamp = packetStamp; // - this->relStamp;
+            relStamp.store(packetStamp.load()); // - this->relStamp;
             // for (uint8_t i = 0; i < 3; i++)
             //     source_originator[i] = this->payload.packet.header.source[i];
         }
@@ -73,11 +73,19 @@ else _dir[0] = ' ';
         if (verbosity) printf(" +%03.3f\t", static_cast<float>(packetStamp - relStamp)/1000.0);        
         printf(" %s ", _dir);
 
+        if (this->buffer_length <= 9) {
+            printf(" INVALID BUFFER LENGTH %u (expected >9)\n", this->buffer_length);
+            return;
+        }
         uint8_t dataLen = this->buffer_length - 9;
         printf(" DATA(%2.2u) ", dataLen);
 
         // 1W fields
         if (this->payload.packet.header.CtrlByte1.asStruct.Protocol) {
+            if (dataLen < 8) {
+                printf(" INVALID 1W DATA LENGTH %u (expected >=8)\n", dataLen);
+                return;
+            }
             unsigned data_length = dataLen - 8;
 
             std::string msg_data = bitrow_to_hex_string(this->payload.buffer + 9, dataLen/*data_length*/);
@@ -236,7 +244,7 @@ else _dir[0] = ' ';
 
         printf("\n");
 
-        relStamp = packetStamp;
+        relStamp.store(packetStamp.load());
     }
 
     std::string iohcPacket::decodeToString(bool verbosity) {
@@ -263,6 +271,10 @@ else _dir[0] = ' ';
            << (int)this->payload.packet.header.target[2]
            << " CMD " << (int)this->payload.packet.header.cmd;
 
+        if (this->buffer_length <= 9) {
+            ss << " INVALID BUFFER LENGTH " << (int)this->buffer_length;
+            return ss.str();
+        }
         uint8_t dataLen = this->buffer_length - 9;
         ss << " DATA(" << std::dec << (int)dataLen << ") ";
         if (dataLen)

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -291,7 +291,7 @@ namespace IOHC {
             sendQueue.push(std::move(iohcTx));
             return static_cast<int>(sendQueue.size());
         });
-        
+
         ets_printf("TX: Queued send batch. Queue depth=%d\n", size);
     }
 
@@ -331,8 +331,8 @@ namespace IOHC {
 
         txComplete = false;
 
-        // 🟢 Sent package with short preamble for first packet
-        transmitPacket(SHORT_PREAMBLE_MS, iohc);
+        // 🟢 Sent package with long preamble for first packet (required for battery powered devices to wake up)
+        transmitPacket(LONG_PREAMBLE_MS, iohc);
 
         // Start ticker for repeats (short preamble)
         Sender.attach_ms(iohc->repeatTime, &iohcRadio::onTxTicker, (void*)this);
@@ -356,8 +356,8 @@ namespace IOHC {
                 ets_printf("TX: Waiting for TXDONE timed out, assuming TXDONE... (state=%s)\n", radioStateToString(radio->radioState));
                 radio->txComplete = true;
             } else {
-            ets_printf("TX: Waiting for TXDONE... (state=%s)\n", radioStateToString(radio->radioState));
-            return;
+                ets_printf("TX: Waiting for TXDONE... (state=%s)\n", radioStateToString(radio->radioState));
+                return;
             }
         }
 
@@ -394,10 +394,10 @@ namespace IOHC {
                 // 👇 Only go RX after all packets
                 ets_printf("TX: All repeats done. Switching to RX\n");
 
-                radio->Sender.detach();
-                Radio::setRx();
-                radio->setRadioState(RadioState::RX);
-                radio->startQueuedSend();
+                        radio->Sender.detach();
+                        Radio::setRx();
+                        radio->setRadioState(RadioState::RX);
+                    radio->startQueuedSend();
             } else {
                 ets_printf("TX: Moving to next packet\n");
      
@@ -405,8 +405,8 @@ namespace IOHC {
                 radio->transmitPacket(SHORT_PREAMBLE_MS, nextIohc);
 
                 if (radio->Sender.currentTimerMillis() != nextIohc->repeatTime) {
-                radio->Sender.detach();
-                radio->Sender.attach_ms(nextIohc->repeatTime, &iohcRadio::onTxTicker, (void*)radio);
+                    radio->Sender.detach();
+                    radio->Sender.attach_ms(nextIohc->repeatTime, &iohcRadio::onTxTicker, (void*)radio);
                 }
             }
         }

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -16,6 +16,7 @@
 
 #include <esp32-hal-gpio.h>
 #include <map>
+#include <memory>
 #include "esp_log.h"
 
 #include <iohcRadio.h>
@@ -24,18 +25,15 @@
 #define LONG_PREAMBLE_MS 1920
 #define SHORT_PREAMBLE_MS 40
 
-TaskHandle_t IOHC::iohcRadio::txTaskHandle = nullptr;
-
 namespace IOHC {
     iohcRadio *iohcRadio::_iohcRadio = nullptr;
-    volatile unsigned long iohcRadio::_g_payload_millis = 0L;
     uint8_t iohcRadio::_flags[2] = {0, 0};
-    volatile bool iohcRadio::send_lock = false;
-    volatile iohcRadio::RadioState iohcRadio::radioState = iohcRadio::RadioState::IDLE;
-    volatile bool iohcRadio::txComplete = false;
+    std::atomic<iohcRadio::RadioState> iohcRadio::radioState = iohcRadio::RadioState::IDLE;
+    std::atomic<bool> iohcRadio::txComplete = false;
+    volatile bool __g_preamble = false;
 
 
-    TaskHandle_t handle_interrupt;
+    static TaskHandle_t handle_interrupt;
     /**
      * The function `handle_interrupt_task` waits for a notification and then calls the `tickerCounter`
      * function if certain conditions are met.
@@ -45,7 +43,7 @@ namespace IOHC {
      * function, it is being cast to a pointer of type `iohcRadio` and then passed to the
      */
     void IRAM_ATTR handle_interrupt_task(void *pvParameters) {
-        static uint32_t thread_notification;
+        uint32_t thread_notification;
         const TickType_t xMaxBlockTime = pdMS_TO_TICKS(655 * 4); // 218.4 );
         while (true) {
             thread_notification = ulTaskNotifyTake(pdTRUE, xMaxBlockTime/*xNoDelay*/); // Attendre la notification
@@ -65,9 +63,6 @@ namespace IOHC {
     void IRAM_ATTR handle_interrupt_fromisr() {
         bool preamble = digitalRead(RADIO_PREAMBLE_DETECTED);
         bool payload = digitalRead(RADIO_PACKET_AVAIL);
-        iohcRadio::txComplete = true;
-        ets_printf("TX: TX-RX DONE detected, flag set\n");
-
 
         if (payload) {
             // When in TX state DIO0 is mapped to PacketSent, otherwise it
@@ -80,15 +75,6 @@ namespace IOHC {
             //} else {
                 iohcRadio::setRadioState(iohcRadio::RadioState::PAYLOAD);
             //}
-
-            // Notify TX task that TXDONE occurred so the next packet can be
-            // scheduled.
-            if (iohcRadio::txTaskHandle) {
-                BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-                vTaskNotifyGiveFromISR(iohcRadio::txTaskHandle,
-                                      &xHigherPriorityTaskWoken);
-                portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
-            }
         } else if (preamble) {
             iohcRadio::setRadioState(iohcRadio::RadioState::PREAMBLE);
         } else {
@@ -99,30 +85,6 @@ namespace IOHC {
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
         vTaskNotifyGiveFromISR(handle_interrupt, &xHigherPriorityTaskWoken);
         portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
-    }
-
-    void iohcRadio::txTaskLoop(void *pvParameters) {
-        iohcRadio *radio = static_cast<iohcRadio *>(pvParameters);
-
-        while (true) {
-            // Wacht tot ISR aangeeft dat TX klaar is
-            ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-
-            // Delay tussen repeats
-            if (radio->iohc && radio->iohc->repeatTime > 0) {
-                vTaskDelay(pdMS_TO_TICKS(radio->iohc->repeatTime));
-            }
-
-            // Verstuur volgend pakket
-            packetSender(radio);
-
-            // Stop de task als alles klaar is
-            if (radio->txCounter >= radio->packets2send.size()) {
-                ets_printf("TX: Batch complete. Deleting TX task.\n");
-                radio->txTaskHandle = nullptr;
-                vTaskDelete(nullptr); // delete zichzelf
-            }
-        }
     }
 
     iohcRadio::iohcRadio() {
@@ -136,14 +98,8 @@ namespace IOHC {
         Radio::setCarrier(Radio::Carrier::Modulation, Radio::Modulation::FSK);
 
         // Attach interrupts to Preamble detected and end of packet sent/received
-        /* TODO this is wrongly named and/or assigned, but work like that*/
-        //        printf("Starting TickTimer Handler...\n");
-        //        TickTimer.attach_us(SM_GRANULARITY_US/*SM_GRANULARITY_MS*/, tickerCounter, this);
 #if defined(RADIO_SX127X)
-        //        attachInterrupt(RADIO_PACKET_AVAIL, i_payload, CHANGE); //
-        //        attachInterrupt(RADIO_PREAMBLE_DETECTED, i_preamble, CHANGE); //
         attachInterrupt(RADIO_DIO0_PIN, handle_interrupt_fromisr, RISING); //CHANGE); //
-        //        attachInterrupt(RADIO_DIO1_PIN, handle_interrupt_fromisr, RISING); // CHANGE); //
         attachInterrupt(RADIO_DIO2_PIN, handle_interrupt_fromisr, RISING); //CHANGE); //
 #elif defined(CC1101)
         attachInterrupt(RADIO_PREAMBLE_DETECTED, i_preamble, RISING);
@@ -230,13 +186,11 @@ namespace IOHC {
         if (radioState == iohcRadio::RadioState::PAYLOAD) {
             // if TX ready?
             if (_flags[0] & RF_IRQFLAGS1_TXREADY) {
-                radio->sent(radio->iohc);
-                Radio::clearFlags();
-                if (radioState != iohcRadio::RadioState::TX) {
-                    Radio::setRx();
-                    radio->setRadioState(iohcRadio::RadioState::RX);
-                }
-                // radio->sent(radio->iohc); // Put after Workaround to permit MQTT sending. No more needed
+                // Radio::clearFlags();
+                // if (radioState != iohcRadio::RadioState::TX) {
+                //     Radio::setRx();
+                //     radio->setRadioState(iohcRadio::RadioState::RX);
+                // }
                 return;
             }
             // if in RX mode?
@@ -297,7 +251,7 @@ namespace IOHC {
      * The `send` function in the `iohcRadio` class sends packets stored in a vector with a specified
      * repeat time.
      *
-     * @param iohcTx `iohcTx` is a reference to a vector of pointers to `iohcPacket` objects.
+     * @param iohcTx `iohcTx` is a reference to a vector of pointers to `iohcPacket` objects. Ownership of the iohcPacket is transfered to this function.
      *
      * @return If `txMode` is true, the `send` function will return early without executing the rest of the
      * code inside the function.
@@ -307,50 +261,77 @@ namespace IOHC {
         startQueuedSend();
     }
 
+    /**
+     * The `send` function in the `iohcRadio` class sends the packet with a specified repeat time.
+     *
+     * @param iohcTx `iohcTx` is a pointer to a `iohcPacket` object. Ownership of the iohcPacket is transfered to this function.
+     *
+     * @return If `txMode` is true, the `send` function will return early without executing the rest of the
+     * code inside the function.
+     */
     void iohcRadio::send(iohcPacket *iohcTx) {
         std::vector<iohcPacket *> packets = { iohcTx };
         send(packets);
     }
 
+    static portMUX_TYPE s_mutex = portMUX_INITIALIZER_UNLOCKED;
+    template<typename T>
+    T iohcRadio::accessInMutex(std::function<T()> handler) {
+        taskENTER_CRITICAL(&s_mutex);
+        T result = handler();
+        taskEXIT_CRITICAL(&s_mutex);
+        return result;
+    }
 
     void iohcRadio::queueSend(std::vector<iohcPacket *> &iohcTx) {
         if (iohcTx.empty()) {
             return;
         }
-        sendQueue.push(std::move(iohcTx));
-        ets_printf("TX: Queued send batch. Queue depth=%d\n", static_cast<int>(sendQueue.size()));
+        auto size = accessInMutex<int>([&iohcTx,this]() {
+            sendQueue.push(std::move(iohcTx));
+            return static_cast<int>(sendQueue.size());
+        });
+        
+        ets_printf("TX: Queued send batch. Queue depth=%d\n", size);
     }
 
-    void iohcRadio::startQueuedSend() {
-        if (radioState == RadioState::TX || packets2send.size() > 0 || sendQueue.empty()) {
-            return;
-        }
-
-        packets2send = std::move(sendQueue.front());
-        sendQueue.pop();
-        txCounter = 0;
-        txComplete = false;
-        ets_printf("TX: Preparing %d packet(s)\n", packets2send.size());
-        setRadioState(RadioState::TX);
-
-        iohc = packets2send[txCounter];
-
-        // 🟢 Set long preamble for first packet
-        Radio::setPreambleLength(LONG_PREAMBLE_MS);
-        ets_printf("TX: Using LONG preamble (%d ms)\n", LONG_PREAMBLE_MS);
-
-        // Send first packet immediately
+    void iohcRadio::transmitPacket(uint16_t preambleLen, iohcPacket *iohc) {
+        digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
+        Radio::setPreambleLength(preambleLen);
         Radio::setStandby();
         Radio::clearFlags();
         Radio::writeBytes(REG_FIFO, iohc->payload.buffer, iohc->buffer_length);
         Radio::setTx();
+        setRadioState(RadioState::TX); 
+
         //packetStamp = esp_timer_get_time();
         //iohc->decode(true); //false);
         //IOHC::lastSendCmd = iohc->payload.packet.header.cmd;
 
-        ets_printf("TX: Sent first packet at %llu us\n", esp_timer_get_time());
+        ets_printf("TX: Sending packet: %s\n", iohc->decodeToString(true).c_str());
 
-        if (iohc->repeat > 0) iohc->repeat--;
+        digitalWrite(RX_LED, false);
+    }
+
+    void iohcRadio::startQueuedSend() {
+        auto canStartOnNextInQueue = accessInMutex<bool>([this]() { return !packets2send.empty() || sendQueue.empty(); });
+        if (radioState == RadioState::TX || canStartOnNextInQueue) {
+            return;
+        }
+
+        auto iohc = accessInMutex<iohcPacket *>([this]() {
+            for(const auto& e: sendQueue.front())
+                packets2send.push(e);
+            sendQueue.pop();
+            return packets2send.front();
+        });
+
+        ets_printf("TX: Preparing %d packet(s)\n", packets2send.size());
+
+        txComplete = false;
+
+        // 🟢 Sent package with short preamble for first packet
+        transmitPacket(SHORT_PREAMBLE_MS, iohc);
 
         // Start ticker for repeats (short preamble)
         Sender.attach_ms(iohc->repeatTime, &iohcRadio::onTxTicker, (void*)this);
@@ -359,24 +340,11 @@ namespace IOHC {
     void iohcRadio::onTxTicker(void *arg) {
         iohcRadio *radio = (iohcRadio *)arg;
 
-        // 🩵 Fallback: Check IRQFLAGS2 (0x3F) for PacketSent in FSK mode
-        uint8_t irqFlags2 = Radio::readByte(0x3F); // REG_IRQFLAGS2
-        if (irqFlags2 & 0x08) { // Bit 3 == PacketSent (TXDONE in FSK)
-            ets_printf("FSK: Detected PacketSent (TXDONE) via register (ISR missed?)\n");
-            Radio::writeByte(0x3F, 0x08); // Clear PacketSent bit
+        // 🩵 Check IRQFLAGS2 (0x3F) for PacketSent in FSK mode (indicates previous transmit is complete)
+        uint8_t irqFlags2 = Radio::readByte(REG_IRQFLAGS2); // REG_IRQFLAGS2
+        if (irqFlags2 & RF_IRQFLAGS2_PACKETSENT) { // Bit 3 == PacketSent (TXDONE in FSK)
+            Radio::writeByte(REG_IRQFLAGS2, RF_IRQFLAGS2_PACKETSENT); // Clear PacketSent bit
             iohcRadio::txComplete = true;
-        }
-
-        // 🛑 Check if all packets are sent
-        if (radio->txCounter >= radio->packets2send.size()) {
-            ets_printf("TX: All packets sent. Stopping Ticker.\n");
-            radio->Sender.detach();
-            for (auto p : radio->packets2send) delete p;
-            radio->packets2send.clear();
-            Radio::setRx();
-            radio->setRadioState(RadioState::RX);
-            radio->startQueuedSend();
-            return;
         }
 
         // ⏳ Wait for TXDONE
@@ -386,189 +354,52 @@ namespace IOHC {
         }
 
         // ✅ TXDONE received
-        radio->txComplete = false;
         ESP_LOGD("RADIO", "TXDONE flag set, ready to send repeat or next packet.\n");
 
+        auto iohc = radio->accessInMutex<iohcPacket *>([&radio]() { 
+            return radio->packets2send.front();
+        });
+
+        radio->sent(iohc);
+
+        radio->txComplete = false;
         // 🔁 Repeat logic
-        if (radio->iohc->repeat > 0) {
-            radio->iohc->repeat--;
-            ets_printf("TX: Repeating current packet (%d repeats left)\n", radio->iohc->repeat);
+        if (iohc->repeat > 0) {
+            iohc->repeat--;
+            ets_printf("TX: Repeating current packet (%d repeats left)\n", iohc->repeat);
+        
+            // 📡 Send packet (short preamble)
+            radio->transmitPacket(SHORT_PREAMBLE_MS, iohc);
         } else {
-            radio->txCounter++;
-            if (radio->txCounter < radio->packets2send.size()) {
-                radio->iohc = radio->packets2send[radio->txCounter];
-                ets_printf("TX: Moving to next packet %d/%d (repeat=%d)\n",
-                        radio->txCounter + 1,
-                        radio->packets2send.size(),
-                        radio->iohc->repeat);
-            }
-        }
+            // No more repeats, advance to next packet when available
+            delete iohc;
 
-        // 👇 Only go RX after all packets
-        if (radio->txCounter >= radio->packets2send.size()) {
-            ets_printf("TX: All repeats done. Switching to RX\n");
-            radio->Sender.detach();
-            for (auto p : radio->packets2send) delete p;
-            radio->packets2send.clear();
-            Radio::setRx();
-            radio->setRadioState(RadioState::RX);
-            radio->startQueuedSend();
-            return;
-        } else {
-            //Radio::setRx();
-            radio->setRadioState(RadioState::TX); // Stay TX until done
-        }
-
-        // 📡 Send next packet (short preamble)
-        Radio::setPreambleLength(SHORT_PREAMBLE_MS);
-        Radio::setStandby();
-        Radio::clearFlags();
-        Radio::writeBytes(REG_FIFO, radio->iohc->payload.buffer, radio->iohc->buffer_length);
-        Radio::setTx();
-        //packetStamp = esp_timer_get_time();
-        //radio->iohc->decode(true); //false);
-        //IOHC::lastSendCmd = radio->iohc->payload.packet.header.cmd;
-
-        ets_printf("TX: Sent packet %d/%d at %llu us\n",
-                radio->txCounter + 1,
-                radio->packets2send.size(),
-                esp_timer_get_time());
-    }
-
-    void iohcRadio::lightTxTask(void *pvParameters) {
-        iohcRadio *radio = static_cast<iohcRadio *>(pvParameters);
-        while (true) {
-            // Wacht tot er werk is
-            ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-
-            while (radio->txCounter < radio->packets2send.size()) {
-                Radio::setStandby();
-                Radio::clearFlags();
-                Radio::writeBytes(REG_FIFO, radio->iohc->payload.buffer, radio->iohc->buffer_length);
-                Radio::setTx();
-                ets_printf("TX: lightTxTask sent packet at %llu us\n", esp_timer_get_time());
-
-                if (radio->iohc->repeat > 0) radio->iohc->repeat--;
-
-                if (radio->iohc->repeat == 0) radio->txCounter++;
-
-                if (radio->iohc->repeatTime > 0)
-                    vTaskDelay(pdMS_TO_TICKS(radio->iohc->repeatTime));
-            }
-
-            // Alles verzonden — delete owned packets then clear
-            for (auto p : radio->packets2send) delete p;
-            radio->packets2send.clear();
-            Radio::setRx();
-            radio->setRadioState(iohcRadio::RadioState::RX);
-        }
-    }
-
-     void iohcRadio::sendAuto(std::vector<iohcPacket *> &iohcTx) {
-         if (radioState == RadioState::TX) {
-             ets_printf("TX: Already transmitting. Ignoring sendAuto()\n");
-             return;
-         }
+            auto nextIohc = radio->accessInMutex<iohcPacket *>([&radio]() { 
+                radio->packets2send.pop();
+                if (!radio->packets2send.empty()) {
+                    return radio->packets2send.front();
+                }
+                return static_cast<iohcPacket *>(nullptr);
+            });
  
-         packets2send = std::move(iohcTx);
-         txCounter = 0;
-         ets_printf("TX: Preparing %d packet(s) for AutoTxRx\n", packets2send.size());
-         setRadioState(RadioState::TX);
- 
-         // Configure AutoTxRx
-         configureAutoTxRx(packets2send[txCounter]);
- 
-         ets_printf("TX: AutoTxRx started\n");
-     }
+            if (nextIohc == nullptr) {
+                // 👇 Only go RX after all packets
+                ets_printf("TX: All repeats done. Switching to RX\n");
 
-    void iohcRadio::configureAutoTxRx(iohcPacket *packet) {
-        ets_printf("TX: Configuring AutoTxRx for repeat=%d interval=%dms\n",
-                   packet->repeat, packet->repeatTime);
-
-        // Set DIO mapping for AutoTxRx (if required)
-        Radio::writeByte(REG_DIOMAPPING1, 0x40); // DIO0 = TxDone, DIO1 = RxDone
-
-        // Set packet payload
-        Radio::writeBytes(REG_FIFO, packet->payload.buffer, packet->buffer_length);
-
-        // Set repeat count (payload->repeat) and interval (payload->repeatTime)
-        //Radio::writeByte(REG_AUTOTX_REPEAT, packet->repeat);
-        //Radio::writeByte(REG_AUTOTX_INTERVAL, packet->repeatTime / 10); // 10ms steps
-
-        // Start AutoTxRx
-        //Radio::writeByte(REG_OPMODE, RF_OPMODE_AUTOTXRX);
-    }
-
-    /**
-     * The function `packetSender` in the `iohcRadio` class handles the transmission of packets using radio
-     * communication, including frequency setting, packet preparation, and handling of repeated
-     * transmissions.
-     * 
-     * @param radio The `radio` parameter in the `packetSender` function is a pointer to an object of type
-     * `iohcRadio`. It is used to access and manipulate data and functions within the `iohcRadio` class.
-     */
-    void IRAM_ATTR iohcRadio::packetSender(iohcRadio *radio) {
-        ets_printf("T1 packetSender() fired at %llu us\n", esp_timer_get_time());
-        if (!radio || radio->packets2send.empty()) {
-            ets_printf("TX: No packets to send. Forcing cleanup.\n");
-            for (auto p : radio->packets2send) delete p;
-            radio->packets2send.clear();
-            Radio::setRx(); // Go back to RX only after stop
-            radio->setRadioState(iohcRadio::RadioState::RX);
-            return;
-        }
-
-        // Check if all packets are sent
-        if (radio->txCounter >= radio->packets2send.size()) {
-            ets_printf("TX: All packets sent in batch.\n");
-            if (!radio->iohc || !radio->iohc->lock) {
-                ets_printf("TX: Unlocking radio and switching to RX.\n");
                 radio->Sender.detach();
-                for (auto p : radio->packets2send) delete p;
-                radio->packets2send.clear();
                 Radio::setRx();
-                radio->setRadioState(iohcRadio::RadioState::RX);
+                radio->setRadioState(RadioState::RX);
+                radio->startQueuedSend();
             } else {
-                ets_printf("TX: Lock is active, keeping radio in STANDBY.\n");
-                radio->txCounter = 0; // Restart batch
+                ets_printf("TX: Moving to next packet\n");
+     
+                // 📡 Send packet (short preamble)
+                radio->transmitPacket(SHORT_PREAMBLE_MS, nextIohc);
+
+                radio->Sender.detach();
+                radio->Sender.attach_ms(nextIohc->repeatTime, &iohcRadio::onTxTicker, (void*)radio);
             }
-            return;
         }
-
-        // Prepare and send next packet
-        radio->iohc = radio->packets2send[radio->txCounter];
-        ets_printf("TX: Sending packet %d/%d (repeat=%d, lock=%s)\n",
-                radio->txCounter + 1,
-                radio->packets2send.size(),
-                radio->iohc->repeat,
-                radio->iohc->lock ? "TRUE" : "FALSE");
-
-        // Set radio to standby, clear flags, and load payload
-        Radio::setStandby();
-        Radio::clearFlags();
-        Radio::writeBytes(REG_FIFO,
-                        radio->iohc->payload.buffer,
-                        radio->iohc->buffer_length);
-
-        packetStamp = esp_timer_get_time();
-
-        // Start transmission
-        Radio::setTx();
-        ets_printf("T2 after setTx() at %llu us\n", esp_timer_get_time());
-        radio->setRadioState(iohcRadio::RadioState::TX);
-
-        // Repeat logic
-        if (radio->iohc->repeat > 0) {
-            radio->iohc->repeat--;
-        }
-
-        if (radio->iohc->repeat == 0) {
-            // Finished this packet
-            radio->txCounter = radio->txCounter + 1;
-        }
-
-        // Toggle TX LED
-        digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
     }
 
     /**
@@ -609,12 +440,11 @@ namespace IOHC {
     bool IRAM_ATTR iohcRadio::receive(bool stats = false) {
         digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
         // bool frmErr = false;
-        iohc = new iohcPacket;
+        auto iohc = std::make_unique<iohcPacket>();
         iohc->buffer_length = 0;
         iohc->frequency = scan_freqs[currentFreqIdx];
 
-        _g_payload_millis = esp_timer_get_time();
-        packetStamp = _g_payload_millis;
+        packetStamp = esp_timer_get_time();
 #if defined(RADIO_SX127X)
         if (stats) {
             iohc->rssi = static_cast<float>(Radio::readByte(REG_RSSIVALUE)) / -2.0f;
@@ -645,6 +475,9 @@ namespace IOHC {
 
         while (Radio::dataAvail()) {
             iohc->payload.buffer[iohc->buffer_length++] = Radio::readByte(REG_FIFO);
+            if (iohc->buffer_length == 32) {
+                break; // avoid buffer overflow
+            }
         }
 
 #elif defined(CC1101)
@@ -706,11 +539,10 @@ namespace IOHC {
 #endif
 
         // Radio::clearFlags();
-        if (rxCB) rxCB(iohc);
+        if (rxCB) rxCB(iohc.get());
         iohc->decode(true); //stats);
         addLogMessage(String(iohc->decodeToString(true).c_str()));
-        //free(iohc); // correct Bug memory
-        delete iohc;
+
         digitalWrite(RX_LED, false);
         return true;
     }
@@ -720,24 +552,8 @@ namespace IOHC {
      * detected on the current channel.
      */
     void IRAM_ATTR iohcRadio::i_preamble() {
-#if defined(RADIO_SX127X)
-        bool preamble = digitalRead(RADIO_PREAMBLE_DETECTED);
-#elif defined(CC1101)
         __g_preamble = true;
-        bool preamble = __g_preamble;
-#endif
-        iohcRadio::setRadioState(preamble ? iohcRadio::RadioState::PREAMBLE : iohcRadio::RadioState::RX);
-    }
-
-    /**
-     * The `i_payload` interrupt handler reads the payload detection pin and sets
-     * the radio state accordingly.
-     */
-    void IRAM_ATTR iohcRadio::i_payload() {
-#if defined(RADIO_SX127X)
-        bool payload = digitalRead(RADIO_PACKET_AVAIL);
-        iohcRadio::setRadioState(payload ? iohcRadio::RadioState::PAYLOAD : iohcRadio::RadioState::RX);
-#endif
+        iohcRadio::setRadioState(iohcRadio::RadioState::PREAMBLE);
     }
 
     const char* iohcRadio::radioStateToString(RadioState state) {

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -304,6 +304,7 @@ namespace IOHC {
         Radio::setTx();
         setRadioState(RadioState::TX); 
 
+        txTimestamp = esp_timer_get_time();
         //packetStamp = esp_timer_get_time();
         //iohc->decode(true); //false);
         //IOHC::lastSendCmd = iohc->payload.packet.header.cmd;
@@ -349,8 +350,15 @@ namespace IOHC {
 
         // ⏳ Wait for TXDONE
         if (!radio->txComplete) {
+            auto now = esp_timer_get_time();
+            if ((now - radio->txTimestamp) > 4*1000*1000) {
+                // 4 seconds since last transmit, something must be wrong! To avoid waiting forever, assuming txComplete and hope for the best
+                ets_printf("TX: Waiting for TXDONE timed out, assuming TXDONE... (state=%s)\n", radioStateToString(radio->radioState));
+                radio->txComplete = true;
+            } else {
             ets_printf("TX: Waiting for TXDONE... (state=%s)\n", radioStateToString(radio->radioState));
             return;
+            }
         }
 
         // ✅ TXDONE received
@@ -396,8 +404,10 @@ namespace IOHC {
                 // 📡 Send packet (short preamble)
                 radio->transmitPacket(SHORT_PREAMBLE_MS, nextIohc);
 
+                if (radio->Sender.currentTimerMillis() != nextIohc->repeatTime) {
                 radio->Sender.detach();
                 radio->Sender.attach_ms(nextIohc->repeatTime, &iohcRadio::onTxTicker, (void*)radio);
+                }
             }
         }
     }

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -95,40 +95,35 @@ namespace IOHC {
             iohcRadio::setRadioState(iohcRadio::RadioState::RX);
         }
 
-    // Notify de RX state machine
-    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-    vTaskNotifyGiveFromISR(handle_interrupt, &xHigherPriorityTaskWoken);
-    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
-}
-
-
-
-
+        // Notify de RX state machine
+        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+        vTaskNotifyGiveFromISR(handle_interrupt, &xHigherPriorityTaskWoken);
+        portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+    }
 
     void iohcRadio::txTaskLoop(void *pvParameters) {
-    iohcRadio *radio = static_cast<iohcRadio *>(pvParameters);
+        iohcRadio *radio = static_cast<iohcRadio *>(pvParameters);
 
-    while (true) {
-        // Wacht tot ISR aangeeft dat TX klaar is
-        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+        while (true) {
+            // Wacht tot ISR aangeeft dat TX klaar is
+            ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
 
-        // Delay tussen repeats
-        if (radio->iohc && radio->iohc->repeatTime > 0) {
-            vTaskDelay(pdMS_TO_TICKS(radio->iohc->repeatTime));
-        }
+            // Delay tussen repeats
+            if (radio->iohc && radio->iohc->repeatTime > 0) {
+                vTaskDelay(pdMS_TO_TICKS(radio->iohc->repeatTime));
+            }
 
-        // Verstuur volgend pakket
-        packetSender(radio);
+            // Verstuur volgend pakket
+            packetSender(radio);
 
-        // Stop de task als alles klaar is
-        if (radio->txCounter >= radio->packets2send.size()) {
-            ets_printf("TX: Batch complete. Deleting TX task.\n");
-            radio->txTaskHandle = nullptr;
-            vTaskDelete(nullptr); // delete zichzelf
+            // Stop de task als alles klaar is
+            if (radio->txCounter >= radio->packets2send.size()) {
+                ets_printf("TX: Batch complete. Deleting TX task.\n");
+                radio->txTaskHandle = nullptr;
+                vTaskDelete(nullptr); // delete zichzelf
+            }
         }
     }
-}
-
 
     iohcRadio::iohcRadio() {
         Radio::initHardware();
@@ -178,26 +173,26 @@ namespace IOHC {
         return _iohcRadio;
     }
 
-/**
- * The `start` function initializes the radio with specified parameters and sets it to receive mode.
- * 
- * @param num_freqs The `num_freqs` parameter in the `start` function represents the number of
- * frequencies to scan. It is of type `uint8_t`, which means it is an unsigned 8-bit integer. This
- * parameter specifies how many frequencies the radio will scan during operation.
- * @param scan_freqs The `scan_freqs` parameter is an array of `uint32_t` values that represent the
- * frequencies to be scanned during the radio operation. The `start` function initializes the radio
- * with the provided frequencies for scanning.
- * @param scanTimeUs The `scanTimeUs` parameter in the `start` function of the `iohcRadio` class
- * represents the time interval in microseconds for scanning frequencies. If a specific value is
- * provided for `scanTimeUs`, it will be used as the scan interval. Otherwise, the default scan
- * interval defined as
- * @param rxCallback The `rxCallback` parameter is of type `IohcPacketDelegate`, which is a delegate or
- * function pointer that will be called when a packet is received by the radio. It is set to `nullptr`
- * by default if not provided during the function call.
- * @param txCallback The `txCallback` parameter in the `start` function of the `iohcRadio` class is of
- * type `IohcPacketDelegate`. It is a callback function that will be called when a packet is
- * transmitted by the radio. This callback function can be provided by the user of the `
- */
+    /**
+     * The `start` function initializes the radio with specified parameters and sets it to receive mode.
+     * 
+     * @param num_freqs The `num_freqs` parameter in the `start` function represents the number of
+     * frequencies to scan. It is of type `uint8_t`, which means it is an unsigned 8-bit integer. This
+     * parameter specifies how many frequencies the radio will scan during operation.
+     * @param scan_freqs The `scan_freqs` parameter is an array of `uint32_t` values that represent the
+     * frequencies to be scanned during the radio operation. The `start` function initializes the radio
+     * with the provided frequencies for scanning.
+     * @param scanTimeUs The `scanTimeUs` parameter in the `start` function of the `iohcRadio` class
+     * represents the time interval in microseconds for scanning frequencies. If a specific value is
+     * provided for `scanTimeUs`, it will be used as the scan interval. Otherwise, the default scan
+     * interval defined as
+     * @param rxCallback The `rxCallback` parameter is of type `IohcPacketDelegate`, which is a delegate or
+     * function pointer that will be called when a packet is received by the radio. It is set to `nullptr`
+     * by default if not provided during the function call.
+     * @param txCallback The `txCallback` parameter in the `start` function of the `iohcRadio` class is of
+     * type `IohcPacketDelegate`. It is a callback function that will be called when a packet is
+     * transmitted by the radio. This callback function can be provided by the user of the `
+     */
     void iohcRadio::start(uint8_t num_freqs, uint32_t *scan_freqs, uint32_t scanTimeUs,
                           IohcPacketDelegate rxCallback = nullptr, IohcPacketDelegate txCallback = nullptr) {
         this->num_freqs = num_freqs;
@@ -214,18 +209,18 @@ namespace IOHC {
         Radio::setRx();
     }
 
-/**
- * The `tickerCounter` function in C++ handles various radio operations based on different conditions
- * and configurations for SX127X and CC1101 radios.
- * 
- * @param radio The `radio` parameter in the `iohcRadio::tickerCounter` function is a pointer to an
- * instance of the `iohcRadio` class. This pointer is used to access and modify the properties and
- * methods of the `iohcRadio` object within the function. The function uses this pointer
- * 
- * @return In the provided code snippet, the function `tickerCounter` is returning different values
- * based on the conditions met within the function. Here is a breakdown of the possible return
- * scenarios:
- */
+    /**
+     * The `tickerCounter` function in C++ handles various radio operations based on different conditions
+     * and configurations for SX127X and CC1101 radios.
+     * 
+     * @param radio The `radio` parameter in the `iohcRadio::tickerCounter` function is a pointer to an
+     * instance of the `iohcRadio` class. This pointer is used to access and modify the properties and
+     * methods of the `iohcRadio` object within the function. The function uses this pointer
+     * 
+     * @return In the provided code snippet, the function `tickerCounter` is returning different values
+     * based on the conditions met within the function. Here is a breakdown of the possible return
+     * scenarios:
+     */
     void IRAM_ATTR iohcRadio::tickerCounter(iohcRadio *radio) {
         // Not need to put in IRAM as we reuse task for µs instead ISR
 #if defined(RADIO_SX127X)
@@ -307,185 +302,167 @@ namespace IOHC {
      * @return If `txMode` is true, the `send` function will return early without executing the rest of the
      * code inside the function.
      */
-
-    /**  
     void iohcRadio::send(std::vector<iohcPacket *> &iohcTx) {
-        if (radioState == iohcRadio::RadioState::TX) return;
+        queueSend(iohcTx);
+        startQueuedSend();
+    }
 
-        packets2send = iohcTx; //std::move(iohcTx); //
-        iohcTx.clear();
+    void iohcRadio::send(iohcPacket *iohcTx) {
+        std::vector<iohcPacket *> packets = { iohcTx };
+        send(packets);
+    }
 
+
+    void iohcRadio::queueSend(std::vector<iohcPacket *> &iohcTx) {
+        if (iohcTx.empty()) {
+            return;
+        }
+        sendQueue.push(std::move(iohcTx));
+        ets_printf("TX: Queued send batch. Queue depth=%d\n", static_cast<int>(sendQueue.size()));
+    }
+
+    void iohcRadio::startQueuedSend() {
+        if (radioState == RadioState::TX || packets2send.size() > 0 || sendQueue.empty()) {
+            return;
+        }
+
+        packets2send = std::move(sendQueue.front());
+        sendQueue.pop();
         txCounter = 0;
-        setRadioState(iohcRadio::RadioState::TX);
-        Sender.attach_ms(packets2send[txCounter]->repeatTime, packetSender, this);
-    }
-    */
+        txComplete = false;
+        ets_printf("TX: Preparing %d packet(s)\n", packets2send.size());
+        setRadioState(RadioState::TX);
 
-void iohcRadio::queueSend(std::vector<iohcPacket *> &iohcTx) {
-    if (iohcTx.empty()) {
-        return;
-    }
-    sendQueue.push(std::move(iohcTx));
-    ets_printf("TX: Queued send batch. Queue depth=%d\n", static_cast<int>(sendQueue.size()));
-}
+        iohc = packets2send[txCounter];
 
-void iohcRadio::startQueuedSend() {
-    if (radioState == RadioState::TX || packets2send.size() > 0 || sendQueue.empty()) {
-        return;
-    }
+        // 🟢 Set long preamble for first packet
+        Radio::setPreambleLength(LONG_PREAMBLE_MS);
+        ets_printf("TX: Using LONG preamble (%d ms)\n", LONG_PREAMBLE_MS);
 
-    packets2send = std::move(sendQueue.front());
-    sendQueue.pop();
-    txCounter = 0;
-    txComplete = false;
-    ets_printf("TX: Preparing %d packet(s)\n", packets2send.size());
-    setRadioState(RadioState::TX);
+        // Send first packet immediately
+        Radio::setStandby();
+        Radio::clearFlags();
+        Radio::writeBytes(REG_FIFO, iohc->payload.buffer, iohc->buffer_length);
+        Radio::setTx();
+        //packetStamp = esp_timer_get_time();
+        //iohc->decode(true); //false);
+        //IOHC::lastSendCmd = iohc->payload.packet.header.cmd;
 
-    iohc = packets2send[txCounter];
+        ets_printf("TX: Sent first packet at %llu us\n", esp_timer_get_time());
 
-    // 🟢 Set long preamble for first packet
-    Radio::setPreambleLength(LONG_PREAMBLE_MS);
-    ets_printf("TX: Using LONG preamble (%d ms)\n", LONG_PREAMBLE_MS);
+        if (iohc->repeat > 0) iohc->repeat--;
 
-    // Send first packet immediately
-    Radio::setStandby();
-    Radio::clearFlags();
-    Radio::writeBytes(REG_FIFO, iohc->payload.buffer, iohc->buffer_length);
-    Radio::setTx();
-    //packetStamp = esp_timer_get_time();
-    //iohc->decode(true); //false);
-    //IOHC::lastSendCmd = iohc->payload.packet.header.cmd;
-
-    ets_printf("TX: Sent first packet at %llu us\n", esp_timer_get_time());
-
-    if (iohc->repeat > 0) iohc->repeat--;
-
-    // Start ticker for repeats (short preamble)
-    Sender.attach_ms(iohc->repeatTime, &iohcRadio::onTxTicker, (void*)this);
-}
-
-void iohcRadio::send(iohcPacket *packet) {
-    std::vector<iohcPacket *> packets = { packet };
-    send(packets);
-}
-
-void iohcRadio::send(std::vector<iohcPacket *> &iohcTx) {
-    queueSend(iohcTx);
-    startQueuedSend();
-}
-
-
- 
-void iohcRadio::onTxTicker(void *arg) {
-    iohcRadio *radio = (iohcRadio *)arg;
-
-    // 🩵 Fallback: Check IRQFLAGS2 (0x3F) for PacketSent in FSK mode
-    uint8_t irqFlags2 = Radio::readByte(0x3F); // REG_IRQFLAGS2
-    if (irqFlags2 & 0x08) { // Bit 3 == PacketSent (TXDONE in FSK)
-        ets_printf("FSK: Detected PacketSent (TXDONE) via register (ISR missed?)\n");
-        Radio::writeByte(0x3F, 0x08); // Clear PacketSent bit
-        iohcRadio::txComplete = true;
+        // Start ticker for repeats (short preamble)
+        Sender.attach_ms(iohc->repeatTime, &iohcRadio::onTxTicker, (void*)this);
     }
 
-    // 🛑 Check if all packets are sent
-    if (radio->txCounter >= radio->packets2send.size()) {
-        ets_printf("TX: All packets sent. Stopping Ticker.\n");
-        radio->Sender.detach();
-        for (auto p : radio->packets2send) delete p;
-        radio->packets2send.clear();
-        Radio::setRx();
-        radio->setRadioState(RadioState::RX);
-        radio->startQueuedSend();
-        return;
-    }
+    void iohcRadio::onTxTicker(void *arg) {
+        iohcRadio *radio = (iohcRadio *)arg;
 
-    // ⏳ Wait for TXDONE
-    if (!radio->txComplete) {
-        ets_printf("TX: Waiting for TXDONE... (state=%s)\n", radioStateToString(radio->radioState));
-        return;
-    }
-
-    // ✅ TXDONE received
-    radio->txComplete = false;
-    ESP_LOGD("RADIO", "TXDONE flag set, ready to send repeat or next packet.\n");
-
-    // 🔁 Repeat logic
-    if (radio->iohc->repeat > 0) {
-        radio->iohc->repeat--;
-        ets_printf("TX: Repeating current packet (%d repeats left)\n", radio->iohc->repeat);
-    } else {
-        radio->txCounter++;
-        if (radio->txCounter < radio->packets2send.size()) {
-            radio->iohc = radio->packets2send[radio->txCounter];
-            ets_printf("TX: Moving to next packet %d/%d (repeat=%d)\n",
-                       radio->txCounter + 1,
-                       radio->packets2send.size(),
-                       radio->iohc->repeat);
-        }
-    }
-
-    // 👇 Only go RX after all packets
-    if (radio->txCounter >= radio->packets2send.size()) {
-        ets_printf("TX: All repeats done. Switching to RX\n");
-        radio->Sender.detach();
-        for (auto p : radio->packets2send) delete p;
-        radio->packets2send.clear();
-        Radio::setRx();
-        radio->setRadioState(RadioState::RX);
-        radio->startQueuedSend();
-        return;
-    } else {
-        //Radio::setRx();
-        radio->setRadioState(RadioState::TX); // Stay TX until done
-    }
-
-    // 📡 Send next packet (short preamble)
-    Radio::setPreambleLength(SHORT_PREAMBLE_MS);
-    Radio::setStandby();
-    Radio::clearFlags();
-    Radio::writeBytes(REG_FIFO, radio->iohc->payload.buffer, radio->iohc->buffer_length);
-    Radio::setTx();
-    //packetStamp = esp_timer_get_time();
-    //radio->iohc->decode(true); //false);
-    //IOHC::lastSendCmd = radio->iohc->payload.packet.header.cmd;
-
-    ets_printf("TX: Sent packet %d/%d at %llu us\n",
-               radio->txCounter + 1,
-               radio->packets2send.size(),
-               esp_timer_get_time());
-}
-
-
- void iohcRadio::lightTxTask(void *pvParameters) {
-    iohcRadio *radio = static_cast<iohcRadio *>(pvParameters);
-    while (true) {
-        // Wacht tot er werk is
-        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-
-        while (radio->txCounter < radio->packets2send.size()) {
-            Radio::setStandby();
-            Radio::clearFlags();
-            Radio::writeBytes(REG_FIFO, radio->iohc->payload.buffer, radio->iohc->buffer_length);
-            Radio::setTx();
-            ets_printf("TX: lightTxTask sent packet at %llu us\n", esp_timer_get_time());
-
-            if (radio->iohc->repeat > 0) radio->iohc->repeat--;
-
-            if (radio->iohc->repeat == 0) radio->txCounter++;
-
-            if (radio->iohc->repeatTime > 0)
-                vTaskDelay(pdMS_TO_TICKS(radio->iohc->repeatTime));
+        // 🩵 Fallback: Check IRQFLAGS2 (0x3F) for PacketSent in FSK mode
+        uint8_t irqFlags2 = Radio::readByte(0x3F); // REG_IRQFLAGS2
+        if (irqFlags2 & 0x08) { // Bit 3 == PacketSent (TXDONE in FSK)
+            ets_printf("FSK: Detected PacketSent (TXDONE) via register (ISR missed?)\n");
+            Radio::writeByte(0x3F, 0x08); // Clear PacketSent bit
+            iohcRadio::txComplete = true;
         }
 
-        // Alles verzonden — delete owned packets then clear
-        for (auto p : radio->packets2send) delete p;
-        radio->packets2send.clear();
-        Radio::setRx();
-        radio->setRadioState(iohcRadio::RadioState::RX);
+        // 🛑 Check if all packets are sent
+        if (radio->txCounter >= radio->packets2send.size()) {
+            ets_printf("TX: All packets sent. Stopping Ticker.\n");
+            radio->Sender.detach();
+            for (auto p : radio->packets2send) delete p;
+            radio->packets2send.clear();
+            Radio::setRx();
+            radio->setRadioState(RadioState::RX);
+            radio->startQueuedSend();
+            return;
+        }
+
+        // ⏳ Wait for TXDONE
+        if (!radio->txComplete) {
+            ets_printf("TX: Waiting for TXDONE... (state=%s)\n", radioStateToString(radio->radioState));
+            return;
+        }
+
+        // ✅ TXDONE received
+        radio->txComplete = false;
+        ESP_LOGD("RADIO", "TXDONE flag set, ready to send repeat or next packet.\n");
+
+        // 🔁 Repeat logic
+        if (radio->iohc->repeat > 0) {
+            radio->iohc->repeat--;
+            ets_printf("TX: Repeating current packet (%d repeats left)\n", radio->iohc->repeat);
+        } else {
+            radio->txCounter++;
+            if (radio->txCounter < radio->packets2send.size()) {
+                radio->iohc = radio->packets2send[radio->txCounter];
+                ets_printf("TX: Moving to next packet %d/%d (repeat=%d)\n",
+                        radio->txCounter + 1,
+                        radio->packets2send.size(),
+                        radio->iohc->repeat);
+            }
+        }
+
+        // 👇 Only go RX after all packets
+        if (radio->txCounter >= radio->packets2send.size()) {
+            ets_printf("TX: All repeats done. Switching to RX\n");
+            radio->Sender.detach();
+            for (auto p : radio->packets2send) delete p;
+            radio->packets2send.clear();
+            Radio::setRx();
+            radio->setRadioState(RadioState::RX);
+            radio->startQueuedSend();
+            return;
+        } else {
+            //Radio::setRx();
+            radio->setRadioState(RadioState::TX); // Stay TX until done
+        }
+
+        // 📡 Send next packet (short preamble)
+        Radio::setPreambleLength(SHORT_PREAMBLE_MS);
+        Radio::setStandby();
+        Radio::clearFlags();
+        Radio::writeBytes(REG_FIFO, radio->iohc->payload.buffer, radio->iohc->buffer_length);
+        Radio::setTx();
+        //packetStamp = esp_timer_get_time();
+        //radio->iohc->decode(true); //false);
+        //IOHC::lastSendCmd = radio->iohc->payload.packet.header.cmd;
+
+        ets_printf("TX: Sent packet %d/%d at %llu us\n",
+                radio->txCounter + 1,
+                radio->packets2send.size(),
+                esp_timer_get_time());
     }
-}
 
+    void iohcRadio::lightTxTask(void *pvParameters) {
+        iohcRadio *radio = static_cast<iohcRadio *>(pvParameters);
+        while (true) {
+            // Wacht tot er werk is
+            ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
 
+            while (radio->txCounter < radio->packets2send.size()) {
+                Radio::setStandby();
+                Radio::clearFlags();
+                Radio::writeBytes(REG_FIFO, radio->iohc->payload.buffer, radio->iohc->buffer_length);
+                Radio::setTx();
+                ets_printf("TX: lightTxTask sent packet at %llu us\n", esp_timer_get_time());
+
+                if (radio->iohc->repeat > 0) radio->iohc->repeat--;
+
+                if (radio->iohc->repeat == 0) radio->txCounter++;
+
+                if (radio->iohc->repeatTime > 0)
+                    vTaskDelay(pdMS_TO_TICKS(radio->iohc->repeatTime));
+            }
+
+            // Alles verzonden — delete owned packets then clear
+            for (auto p : radio->packets2send) delete p;
+            radio->packets2send.clear();
+            Radio::setRx();
+            radio->setRadioState(iohcRadio::RadioState::RX);
+        }
+    }
 
      void iohcRadio::sendAuto(std::vector<iohcPacket *> &iohcTx) {
          if (radioState == RadioState::TX) {
@@ -503,7 +480,6 @@ void iohcRadio::onTxTicker(void *arg) {
  
          ets_printf("TX: AutoTxRx started\n");
      }
-
 
     void iohcRadio::configureAutoTxRx(iohcPacket *packet) {
         ets_printf("TX: Configuring AutoTxRx for repeat=%d interval=%dms\n",
@@ -523,92 +499,88 @@ void iohcRadio::onTxTicker(void *arg) {
         //Radio::writeByte(REG_OPMODE, RF_OPMODE_AUTOTXRX);
     }
 
-/**
- * The function `packetSender` in the `iohcRadio` class handles the transmission of packets using radio
- * communication, including frequency setting, packet preparation, and handling of repeated
- * transmissions.
- * 
- * @param radio The `radio` parameter in the `packetSender` function is a pointer to an object of type
- * `iohcRadio`. It is used to access and manipulate data and functions within the `iohcRadio` class.
- */
- 
-void IRAM_ATTR iohcRadio::packetSender(iohcRadio *radio) {
-    ets_printf("T1 packetSender() fired at %llu us\n", esp_timer_get_time());
-    if (!radio || radio->packets2send.empty()) {
-        ets_printf("TX: No packets to send. Forcing cleanup.\n");
-        for (auto p : radio->packets2send) delete p;
-        radio->packets2send.clear();
-        Radio::setRx(); // Go back to RX only after stop
-        radio->setRadioState(iohcRadio::RadioState::RX);
-        return;
-    }
-
-    // Check if all packets are sent
-    if (radio->txCounter >= radio->packets2send.size()) {
-        ets_printf("TX: All packets sent in batch.\n");
-        if (!radio->iohc || !radio->iohc->lock) {
-            ets_printf("TX: Unlocking radio and switching to RX.\n");
-            radio->Sender.detach();
+    /**
+     * The function `packetSender` in the `iohcRadio` class handles the transmission of packets using radio
+     * communication, including frequency setting, packet preparation, and handling of repeated
+     * transmissions.
+     * 
+     * @param radio The `radio` parameter in the `packetSender` function is a pointer to an object of type
+     * `iohcRadio`. It is used to access and manipulate data and functions within the `iohcRadio` class.
+     */
+    void IRAM_ATTR iohcRadio::packetSender(iohcRadio *radio) {
+        ets_printf("T1 packetSender() fired at %llu us\n", esp_timer_get_time());
+        if (!radio || radio->packets2send.empty()) {
+            ets_printf("TX: No packets to send. Forcing cleanup.\n");
             for (auto p : radio->packets2send) delete p;
             radio->packets2send.clear();
-            Radio::setRx();
+            Radio::setRx(); // Go back to RX only after stop
             radio->setRadioState(iohcRadio::RadioState::RX);
-        } else {
-            ets_printf("TX: Lock is active, keeping radio in STANDBY.\n");
-            radio->txCounter = 0; // Restart batch
+            return;
         }
-        return;
+
+        // Check if all packets are sent
+        if (radio->txCounter >= radio->packets2send.size()) {
+            ets_printf("TX: All packets sent in batch.\n");
+            if (!radio->iohc || !radio->iohc->lock) {
+                ets_printf("TX: Unlocking radio and switching to RX.\n");
+                radio->Sender.detach();
+                for (auto p : radio->packets2send) delete p;
+                radio->packets2send.clear();
+                Radio::setRx();
+                radio->setRadioState(iohcRadio::RadioState::RX);
+            } else {
+                ets_printf("TX: Lock is active, keeping radio in STANDBY.\n");
+                radio->txCounter = 0; // Restart batch
+            }
+            return;
+        }
+
+        // Prepare and send next packet
+        radio->iohc = radio->packets2send[radio->txCounter];
+        ets_printf("TX: Sending packet %d/%d (repeat=%d, lock=%s)\n",
+                radio->txCounter + 1,
+                radio->packets2send.size(),
+                radio->iohc->repeat,
+                radio->iohc->lock ? "TRUE" : "FALSE");
+
+        // Set radio to standby, clear flags, and load payload
+        Radio::setStandby();
+        Radio::clearFlags();
+        Radio::writeBytes(REG_FIFO,
+                        radio->iohc->payload.buffer,
+                        radio->iohc->buffer_length);
+
+        packetStamp = esp_timer_get_time();
+
+        // Start transmission
+        Radio::setTx();
+        ets_printf("T2 after setTx() at %llu us\n", esp_timer_get_time());
+        radio->setRadioState(iohcRadio::RadioState::TX);
+
+        // Repeat logic
+        if (radio->iohc->repeat > 0) {
+            radio->iohc->repeat--;
+        }
+
+        if (radio->iohc->repeat == 0) {
+            // Finished this packet
+            radio->txCounter = radio->txCounter + 1;
+        }
+
+        // Toggle TX LED
+        digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
     }
 
-    // Prepare and send next packet
-    radio->iohc = radio->packets2send[radio->txCounter];
-    ets_printf("TX: Sending packet %d/%d (repeat=%d, lock=%s)\n",
-               radio->txCounter + 1,
-               radio->packets2send.size(),
-               radio->iohc->repeat,
-               radio->iohc->lock ? "TRUE" : "FALSE");
-
-    // Set radio to standby, clear flags, and load payload
-    Radio::setStandby();
-    Radio::clearFlags();
-    Radio::writeBytes(REG_FIFO,
-                      radio->iohc->payload.buffer,
-                      radio->iohc->buffer_length);
-
-    packetStamp = esp_timer_get_time();
-
-    // Start transmission
-    Radio::setTx();
-    ets_printf("T2 after setTx() at %llu us\n", esp_timer_get_time());
-    radio->setRadioState(iohcRadio::RadioState::TX);
-
-    // Repeat logic
-    if (radio->iohc->repeat > 0) {
-        radio->iohc->repeat--;
-    }
-
-    if (radio->iohc->repeat == 0) {
-        // Finished this packet
-        radio->txCounter = radio->txCounter + 1;
-    }
-
-    // Toggle TX LED
-    digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-}
-
-
-
-
-/**
- * The `sent` function in the `iohcRadio` class checks if a callback function `txCB` is set and calls
- * it with a packet as a parameter, returning the result.
- * 
- * @param packet The `packet` parameter is a pointer to an object of type `iohcPacket`.
- * 
- * @return The `sent` function is returning a boolean value, which is determined by the result of
- * calling the `txCB` function with the `packet` parameter. If `txCB` is not null, the return value
- * will be the result of calling `txCB(packet)`, otherwise it will be `false`.
- */
+    /**
+     * The `sent` function in the `iohcRadio` class checks if a callback function `txCB` is set and calls
+     * it with a packet as a parameter, returning the result.
+     * 
+     * @param packet The `packet` parameter is a pointer to an object of type `iohcPacket`.
+     * 
+     * @return The `sent` function is returning a boolean value, which is determined by the result of
+     * calling the `txCB` function with the `packet` parameter. If `txCB` is not null, the return value
+     * will be the result of calling `txCB(packet)`, otherwise it will be `false`.
+     */
     bool IRAM_ATTR iohcRadio::sent(iohcPacket *packet) {
         bool ret = false;
         if (packet) {
@@ -623,17 +595,17 @@ void IRAM_ATTR iohcRadio::packetSender(iohcRadio *radio) {
     }
 
     //    static uint8_t RF96lnaMap[] = { 0, 0, 6, 12, 24, 36, 48, 48 };
-/**
- * The `iohcRadio::receive` function in C++ toggles an LED, reads radio data, processes it, and
- * triggers a callback function.
- * 
- * @param stats The `stats` parameter in the `iohcRadio::receive` function is a boolean parameter that
- * is used to determine whether to gather additional statistics during the radio reception process. If
- * `stats` is set to `true`, the function will collect and process additional information such as RSSI
- * (Received Signal
- * 
- * @return The function `iohcRadio::receive` is returning a boolean value `true`.
- */
+    /**
+     * The `iohcRadio::receive` function in C++ toggles an LED, reads radio data, processes it, and
+     * triggers a callback function.
+     * 
+     * @param stats The `stats` parameter in the `iohcRadio::receive` function is a boolean parameter that
+     * is used to determine whether to gather additional statistics during the radio reception process. If
+     * `stats` is set to `true`, the function will collect and process additional information such as RSSI
+     * (Received Signal
+     * 
+     * @return The function `iohcRadio::receive` is returning a boolean value `true`.
+     */
     bool IRAM_ATTR iohcRadio::receive(bool stats = false) {
         digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
         // bool frmErr = false;
@@ -743,10 +715,10 @@ void IRAM_ATTR iohcRadio::packetSender(iohcRadio *radio) {
         return true;
     }
 
-/**
- * The `i_preamble` interrupt handler updates the radio state when a preamble is
- * detected on the current channel.
- */
+    /**
+     * The `i_preamble` interrupt handler updates the radio state when a preamble is
+     * detected on the current channel.
+     */
     void IRAM_ATTR iohcRadio::i_preamble() {
 #if defined(RADIO_SX127X)
         bool preamble = digitalRead(RADIO_PREAMBLE_DETECTED);
@@ -757,10 +729,10 @@ void IRAM_ATTR iohcRadio::packetSender(iohcRadio *radio) {
         iohcRadio::setRadioState(preamble ? iohcRadio::RadioState::PREAMBLE : iohcRadio::RadioState::RX);
     }
 
-/**
- * The `i_payload` interrupt handler reads the payload detection pin and sets
- * the radio state accordingly.
- */
+    /**
+     * The `i_payload` interrupt handler reads the payload detection pin and sets
+     * the radio state accordingly.
+     */
     void IRAM_ATTR iohcRadio::i_payload() {
 #if defined(RADIO_SX127X)
         bool payload = digitalRead(RADIO_PACKET_AVAIL);
@@ -769,16 +741,16 @@ void IRAM_ATTR iohcRadio::packetSender(iohcRadio *radio) {
     }
 
     const char* iohcRadio::radioStateToString(RadioState state) {
-    switch (state) {
-        case RadioState::IDLE:     return "IDLE";
-        case RadioState::RX:       return "RX";
-        case RadioState::TX:       return "TX";
-        case RadioState::PREAMBLE: return "PREAMBLE";
-        case RadioState::PAYLOAD:  return "PAYLOAD";
-        case RadioState::LOCKED:   return "LOCKED";
-        case RadioState::ERROR:    return "ERROR";
-        default:                   return "UNKNOWN";
-    }
+        switch (state) {
+            case RadioState::IDLE:     return "IDLE";
+            case RadioState::RX:       return "RX";
+            case RadioState::TX:       return "TX";
+            case RadioState::PREAMBLE: return "PREAMBLE";
+            case RadioState::PAYLOAD:  return "PAYLOAD";
+            case RadioState::LOCKED:   return "LOCKED";
+            case RadioState::ERROR:    return "ERROR";
+            default:                   return "UNKNOWN";
+        }
     }
 
 

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -364,6 +364,11 @@ void iohcRadio::startQueuedSend() {
     Sender.attach_ms(iohc->repeatTime, &iohcRadio::onTxTicker, (void*)this);
 }
 
+void iohcRadio::send(iohcPacket *packet) {
+    std::vector<iohcPacket *> packets = { packet };
+    send(packets);
+}
+
 void iohcRadio::send(std::vector<iohcPacket *> &iohcTx) {
     queueSend(iohcTx);
     startQueuedSend();

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -152,11 +152,12 @@ namespace IOHC {
         switch (cmd) {
             case RemoteButton::Pair: {
                 // 0x2e: 0x1120 + target broadcast + source + 0x2e00 + sequence + hmac
-                packets2send.clear();
 
+                std::vector<iohcPacket *> packets2send;
 //                for (auto&r: remotes) {
 
                     auto* packet = new iohcPacket;
+                    packets2send.push_back(packet);
                     IOHC::iohcRemote1W::forgePacket(packet, r.type[0]);
                     // Packet length
                     packet->payload.packet.header.CtrlByte1.asStruct.MsgLen += sizeof(_p0x2e);
@@ -184,7 +185,6 @@ namespace IOHC {
 
                     packet->buffer_length = packet->payload.packet.header.CtrlByte1.asStruct.MsgLen + 1;
 
-                    packets2send.push_back(packet);
                     // if (typn) packet->payload.packet.header.CtrlByte2.asStruct.LPM = 0; //TODO only first is LPM
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 //                }
@@ -200,12 +200,13 @@ namespace IOHC {
 
             case RemoteButton::Remove: {
                 // 0x39: 0x1c00 + target broadcast + source + 0x3900 + sequence + hmac
-                packets2send.clear();
 
+                std::vector<iohcPacket *> packets2send;
 //                for (auto&r: remotes) {
 
 
                     auto* packet = new iohcPacket;
+                    packets2send.push_back(packet);
                     IOHC::iohcRemote1W::forgePacket(packet, r.type[0]);
                     // Packet length
                     //                    packet->payload.packet.header.CtrlByte1.asStruct.MsgLen = sizeof(_header) - 1;
@@ -233,7 +234,6 @@ namespace IOHC {
 
                     packet->buffer_length = packet->payload.packet.header.CtrlByte1.asStruct.MsgLen + 1;
 
-                    packets2send.push_back(packet);
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 //                }
                 _radioInstance->send(packets2send);
@@ -249,11 +249,12 @@ namespace IOHC {
 
             case RemoteButton::Add: {
                 // 0x30: 0x1100 + target broadcast + source + 0x3000 + ???
-                packets2send.clear();
 
+                std::vector<iohcPacket *> packets2send;
 //                for (auto&r: remotes) {
 
                     auto* packet = new iohcPacket;
+                    packets2send.push_back(packet);
                     IOHC::iohcRemote1W::forgePacket(packet, r.type[0]);
                     // Packet length
                     packet->payload.packet.header.CtrlByte1.asStruct.MsgLen += sizeof(_p0x30);
@@ -282,7 +283,7 @@ namespace IOHC {
 
                     packet->buffer_length = packet->payload.packet.header.CtrlByte1.asStruct.MsgLen + 1;
 
-                    packets2send.push_back(packet);
+
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 //                }
                 _radioInstance->send(packets2send);
@@ -293,12 +294,14 @@ namespace IOHC {
                 break;
             }
            default: {
-                packets2send.clear();
-
                 // 0x00: 0x1600 + target broadcast + source + 0x00 + Originator + ACEI + Main Param + FP1 + FP2 + sequence + hmac
+
+                std::vector<iohcPacket *> packets2send;
 //                for (auto&r: remotes) {
 
                     auto* packet = new iohcPacket;
+                    packets2send.push_back(packet);
+
                     IOHC::iohcRemote1W::forgePacket(packet, r.type[0]);
                     // Packet length
                     // packet->payload.packet.header.CtrlByte1.asStruct.MsgLen += sizeof(_p0x00);
@@ -628,15 +631,15 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
                     // }
                     packet->buffer_length = packet->payload.packet.header.CtrlByte1.asStruct.MsgLen + 1;
 
-                    packets2send.push_back(packet);
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
+
+                    _radioInstance->send(packets2send);
+
+                    display1WAction(r.node, remoteButtonToString(cmd), "TX", r.name.c_str());
+                    Serial.printf("%s position: %.0f%%\n", r.name.c_str(), r.positionTracker.getPosition());
+                    display1WPosition(r.node, r.positionTracker.getPosition(), r.name.c_str());
+                    break;
                 }
-                _radioInstance->send(packets2send);
-                display1WAction(r.node, remoteButtonToString(cmd), "TX", r.name.c_str());
-                Serial.printf("%s position: %.0f%%\n", r.name.c_str(), r.positionTracker.getPosition());
-                display1WPosition(r.node, r.positionTracker.getPosition(), r.name.c_str());
-                break;
-//            }
         }
         this->save(); // Save sequence number
     }

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -658,14 +658,13 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
         JsonDocument doc; 
 
         DeserializationError error = deserializeJson(doc, f); 
+        f.close();
 
         if (error) {
             Serial.print("Failed to parse JSON: ");
             Serial.println(error.c_str());
-            f.close();
             return false;
         }
-        f.close();
 
         // Iterate through the JSON object
         bool updateFile = false;

--- a/src/iohcSystemTable.cpp
+++ b/src/iohcSystemTable.cpp
@@ -94,8 +94,14 @@ namespace IOHC {
 
         fs::File f = LittleFS.open(IOHC_SYS_TABLE, "r", true);
         /*Dynamic*/JsonDocument doc; //(2048);
-        deserializeJson(doc, f);
+        DeserializationError error = deserializeJson(doc, f);
         f.close();
+
+        if (error) {
+            Serial.print("Failed to parse JSON: ");
+            Serial.println(error.c_str());
+            return false;
+        }
 
         // Iterate through the JSON object
         for (JsonPair kv : doc.as<JsonObject>())  {

--- a/src/log_buffer.cpp
+++ b/src/log_buffer.cpp
@@ -3,6 +3,8 @@
 #include <Arduino.h>
 #include <log_buffer.h>
 #include <user_config.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 #if defined(WEBSERVER)
 #include <web_server_handler.h>
@@ -14,13 +16,17 @@
 namespace {
     std::deque<String> logDeque;
     const size_t MAX_LOG_ENTRIES = 50;
+    SemaphoreHandle_t logMutex = xSemaphoreCreateMutex();
 }
 
 void addLogMessage(const String &msg) {
-    if (logDeque.size() >= MAX_LOG_ENTRIES) {
-        logDeque.pop_front();
+    if (xSemaphoreTake(logMutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+        if (logDeque.size() >= MAX_LOG_ENTRIES) {
+            logDeque.pop_front();
+        }
+        logDeque.push_back(msg);
+        xSemaphoreGive(logMutex);
     }
-    logDeque.push_back(msg);
 #if defined(WEBSERVER)
     //broadcastLog(msg);
 #endif
@@ -30,5 +36,10 @@ void addLogMessage(const String &msg) {
 }
 
 std::vector<String> getLogMessages() {
-    return std::vector<String>(logDeque.begin(), logDeque.end());
+    std::vector<String> result;
+    if (xSemaphoreTake(logMutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+        result = std::vector<String>(logDeque.begin(), logDeque.end());
+        xSemaphoreGive(logMutex);
+    }
+    return result;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,9 +71,6 @@ uint8_t keyCap[16] = {};
 IOHC::iohcRadio *radioInstance;
 IOHC::iohcPacket *radioPackets[IOHC_INBOUND_MAX_PACKETS];
 
-std::vector<IOHC::iohcPacket *> packets2send{};
-std::vector<IOHC::iohcPacket *> packets2send_tmp{};
-
 uint8_t nextPacket = 0;
 
 IOHC::iohcSystemTable *sysTable;
@@ -228,7 +225,6 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
             // 0x0b OverKiz 0x0c Atlantic
             std::vector<uint8_t> toSend = {0xff, 0xc0, 0xba, 0x11, 0xad, 0x0b, 0xcc, 0x00, 0x00};
 
-            packets2send.clear();
             auto* packet = new iohcPacket;
             forgePacket(packet, toSend);
 
@@ -241,9 +237,8 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
             packet->delayed = 250;
             packet->repeat = 0;
 
-            packets2send.push_back(packet);
             digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-            radioInstance->send(packets2send);
+            radioInstance->send(packet);
             break;
         }
         case iohcDevice::RECEIVED_DISCOVER_ANSWER_0x29: {
@@ -263,22 +258,21 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
             // std::vector<uint8_t> toSend = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06}; // 38
             std::vector<uint8_t> toSend = {}; // SEND_DISCOVER_ACTUATOR_0x2C
 
-            packets2send.clear();
-            packets2send.push_back(new IOHC::iohcPacket);
-            forgePacket(packets2send.back(), toSend);
+            auto* packet = new iohcPacket;
+            forgePacket(packet, toSend);
 
-            // packets2send.back()->payload.packet.header.cmd = 0x38;
-            packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_ACTUATOR_0x2C;
+            // packet->payload.packet.header.cmd = 0x38;
+            packet->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_ACTUATOR_0x2C;
             // cozyDevice2W->memorizeSend.memorizedData = toSend;
             // cozyDevice2W->memorizeSend.memorizedCmd = SEND_DISCOVER_ACTUATOR_0x2C;
 
             /* Swap */
-            memcpy(packets2send.back()->payload.packet.header.source, iohc->payload.packet.header.target, 3);
-            memcpy(packets2send.back()->payload.packet.header.target, iohc->payload.packet.header.source, 3);
+            memcpy(packet->payload.packet.header.source, iohc->payload.packet.header.target, 3);
+            memcpy(packet->payload.packet.header.target, iohc->payload.packet.header.source, 3);
 
-            packets2send.back()->repeat = 1;
+            packet->repeat = 1;
 
-            radioInstance->send(packets2send);
+            radioInstance->send(packet);
             digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
             break;
         }
@@ -294,20 +288,19 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
 
             std::vector<uint8_t> toSend = {};
 
-            packets2send.clear();
-            packets2send.push_back(new IOHC::iohcPacket);
-            forgePacket(packets2send.back(), toSend);
+            auto* packet = new iohcPacket;
+            forgePacket(packet, toSend);
 
-            packets2send.back()->payload.packet.header.cmd = IOHC::iohcDevice::SEND_DISCOVER_ACTUATOR_ACK_0x2D;
+            packet->payload.packet.header.cmd = IOHC::iohcDevice::SEND_DISCOVER_ACTUATOR_ACK_0x2D;
 
             /* Swap */
-            memcpy(packets2send.back()->payload.packet.header.source, iohc->payload.packet.header.target, 3);
-            memcpy(packets2send.back()->payload.packet.header.target, iohc->payload.packet.header.source, 3);
+            memcpy(packet->payload.packet.header.source, iohc->payload.packet.header.target, 3);
+            memcpy(packet->payload.packet.header.target, iohc->payload.packet.header.source, 3);
 
-            packets2send.back()->delayed = 250;
-            packets2send.back()->repeat = 0;
+            packet->delayed = 250;
+            packet->repeat = 0;
 
-            radioInstance->send(packets2send);
+            radioInstance->send(packet);
             digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
             break;
         }
@@ -346,20 +339,19 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
             std::vector<uint8_t> toSend;
             toSend.assign(encrypted_key, encrypted_key + 16);
 
-            packets2send.clear();
-            packets2send.push_back(new IOHC::iohcPacket);
-            forgePacket(packets2send.back(), toSend);
+            auto* packet = new iohcPacket;
+            forgePacket(packet, toSend);
 
-            packets2send.back()->payload.packet.header.cmd = IOHC::iohcDevice::SEND_KEY_TRANSFERT_0x32;
+            packet->payload.packet.header.cmd = IOHC::iohcDevice::SEND_KEY_TRANSFERT_0x32;
             cozyDevice2W->memorizeSend.memorizedCmd = IOHC::iohcDevice::SEND_KEY_TRANSFERT_0x32;
 
             /* Swap */
-            memcpy(packets2send.back()->payload.packet.header.source, iohc->payload.packet.header.target, 3);
-            memcpy(packets2send.back()->payload.packet.header.target, iohc->payload.packet.header.source, 3);
+            memcpy(packet->payload.packet.header.source, iohc->payload.packet.header.target, 3);
+            memcpy(packet->payload.packet.header.target, iohc->payload.packet.header.source, 3);
 
-            packets2send.back()->repeat = 0;
+            packet->repeat = 0;
 
-            radioInstance->send(packets2send);
+            radioInstance->send(packet);
             digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
             break;
         }
@@ -407,10 +399,9 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
                 std::vector<uint8_t> IVdata = cozyDevice2W->memorizeSend.memorizedData;
                 IVdata.insert(IVdata.begin(), cozyDevice2W->memorizeSend.memorizedCmd);
 
-                packets2send.clear();
-                packets2send.push_back(new IOHC::iohcPacket);
+                auto* packet = new iohcPacket;
 
-                packets2send.back()->payload.packet.header.cmd = IOHC::iohcDevice::SEND_CHALLENGE_ANSWER_0x3D;
+                packet->payload.packet.header.cmd = IOHC::iohcDevice::SEND_CHALLENGE_ANSWER_0x3D;
 
                 unsigned char initial_value[16];
                 constructInitialValue(IVdata, initial_value, IVdata.size(), challengeAsked, nullptr);
@@ -418,7 +409,7 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
                 uint8_t dataLen = 6;
 
                 if (cozyDevice2W->memorizeSend.memorizedCmd == IOHC::iohcDevice::RECEIVED_ASK_CHALLENGE_0x31) {
-                    packets2send.back()->payload.packet.header.cmd = IOHC::iohcDevice::SEND_KEY_TRANSFERT_0x32;
+                    packet->payload.packet.header.cmd = IOHC::iohcDevice::SEND_KEY_TRANSFERT_0x32;
                     dataLen = 16;
                     IVdata = {IOHC::iohcDevice::RECEIVED_ASK_CHALLENGE_0x31};
                     constructInitialValue(IVdata, initial_value, 1, challengeAsked, nullptr);
@@ -431,22 +422,22 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
 
                 std::vector<uint8_t> toSend;
                 toSend.assign(initial_value, initial_value + dataLen);
-                forgePacket(packets2send.back(), toSend);
+                forgePacket(packet, toSend);
 
                 /* Swap */
-                memcpy(packets2send.back()->payload.packet.header.source, iohc->payload.packet.header.target, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, iohc->payload.packet.header.source, 3);
+                memcpy(packet->payload.packet.header.source, iohc->payload.packet.header.target, 3);
+                memcpy(packet->payload.packet.header.target, iohc->payload.packet.header.source, 3);
 
-                packets2send.back()->repeatTime = 6;
-                packets2send.back()->repeat = 1;
+                packet->repeatTime = 6;
+                packet->repeat = 1;
 
-                radioInstance->send(packets2send);
+                radioInstance->send(packet);
 
                 // Serial.print("IV used for key encryption: ");
                 // for (int i = 0; i < 16; i++)
                 //     Serial.printf("%02X ", initial_value[i]);
                 // Serial.println();
-                printf("Challenge response %2.2X: ", packets2send[0]->payload.packet.header.cmd);
+                printf("Challenge response %2.2X: ", packet->payload.packet.header.cmd);
                 for (int i = 0; i < dataLen; i++)
                     printf("%02X ", initial_value[i]);
                 printf("\n");
@@ -499,20 +490,20 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
             std::vector<uint8_t> toSend = {0x4d, 0x59, 0x5f, 0x47, 0x41, 0x54, 0x45, 0x57, 0x41, 0x59};
             toSend.resize(16);
             
-            packets2send.clear();
-            packets2send.push_back(new IOHC::iohcPacket);
-            forgePacket(packets2send.back(), toSend);
+            auto* packet = new iohcPacket;
 
-            packets2send.back()->payload.packet.header.cmd = 0x51;
+            forgePacket(packet, toSend);
+
+            packet->payload.packet.header.cmd = 0x51;
 
             /* Swap */
-            memcpy(packets2send.back()->payload.packet.header.source, cozyDevice2W->gateway, 3);
-            memcpy(packets2send.back()->payload.packet.header.target, iohc->payload.packet.header.source, 3);
+            memcpy(packet->payload.packet.header.source, cozyDevice2W->gateway, 3);
+            memcpy(packet->payload.packet.header.target, iohc->payload.packet.header.source, 3);
 
-            packets2send.back()->delayed = 50;
-            packets2send.back()->repeat = 0;
+            packet->delayed = 50;
+            packet->repeat = 0;
 
-            radioInstance->send(packets2send);
+            radioInstance->send(packet);
             digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
             }
             break;
@@ -706,20 +697,18 @@ void txUserBuffer(Tokens *cmd) {
         return;
     }
     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-    if (!packets2send[0])
-        packets2send[0] = new IOHC::iohcPacket;
+    auto *packet = new iohcPacket;
 
     if (cmd->size() == 3)
-        packets2send[0]->frequency = frequencies[atoi(cmd->at(2).c_str()) - 1];
+        packet->frequency = frequencies[atoi(cmd->at(2).c_str()) - 1];
     else
-        packets2send[0]->frequency = 0;
+        packet->frequency = 0;
 
-    packets2send[0]->buffer_length = hexStringToBytes(cmd->at(1), packets2send[0]->payload.buffer);
-    packets2send[0]->repeatTime = 35;
-    packets2send[0]->repeat = 1;
-    packets2send[1] = nullptr;
+    packet->buffer_length = hexStringToBytes(cmd->at(1), packet->payload.buffer);
+    packet->repeatTime = 35;
+    packet->repeat = 1;
 
-    radioInstance->send(packets2send);
+    radioInstance->send(packet);
     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -454,26 +454,23 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
                 doc["type"] = "1W";
                 uint16_t main = (iohc->payload.packet.msg.p0x00_14.main[0] << 8) | iohc->payload.packet.msg.p0x00_14.main[1];
                 const char *action = "unknown";
+                IOHC::RemoteButton btn;
+                bool unknown = false;
                 switch (main) {
-                    case 0x0000: action = "OPEN"; break;
-                    case 0xC800: action = "CLOSE"; break;
-                    case 0xD200: action = "STOP"; break;
-                    case 0xD803: action = "VENT"; break;
-                    case 0x6400: action = "FORCE"; break;
-                    default: break;
+                    case 0x0000: action = "OPEN"; btn = IOHC::RemoteButton::Open; break;
+                    case 0xC800: action = "CLOSE"; btn = IOHC::RemoteButton::Close; break;
+                    case 0xD200: action = "STOP"; btn = IOHC::RemoteButton::Stop; break;
+                    case 0xD803: action = "VENT"; btn = IOHC::RemoteButton::Vent; break;
+                    case 0x6400: action = "FORCE"; btn = IOHC::RemoteButton::ForceOpen; break;
+                    default: unknown = true; break;
                 }
                 doc["action"] = action;
                 display1WAction(iohc->payload.packet.header.source, action, "RX");
-                if (const auto *map = remoteMap->find(iohc->payload.packet.header.source)) {
-                    IOHC::RemoteButton btn;
-                    if (!strcmp(action, "OPEN")) btn = IOHC::RemoteButton::Open;
-                    else if (!strcmp(action, "CLOSE")) btn = IOHC::RemoteButton::Close;
-                    else if (!strcmp(action, "STOP")) btn = IOHC::RemoteButton::Stop;
-                    else if (!strcmp(action, "VENT")) btn = IOHC::RemoteButton::Vent;
-                    else if (!strcmp(action, "FORCE")) btn = IOHC::RemoteButton::ForceOpen;
-                    else btn = IOHC::RemoteButton::Stop; // default to avoid uninitialized
-                    for (const auto &desc : map->devices) {
-                        iohcRemote1W::getInstance()->handleRemoteAction(btn, desc);
+                if (!unknown) {
+                    if (const auto *map = remoteMap->find(iohc->payload.packet.header.source)) {
+                        for (const auto &desc : map->devices) {
+                            iohcRemote1W::getInstance()->handleRemoteAction(btn, desc);
+                        }
                     }
                 }
             } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,7 +69,6 @@ uint8_t keyCap[16] = {};
 //uint8_t source_originator[3] = {0};
 
 IOHC::iohcRadio *radioInstance;
-IOHC::iohcPacket *radioPackets[IOHC_INBOUND_MAX_PACKETS];
 
 uint8_t nextPacket = 0;
 
@@ -193,9 +192,9 @@ void IRAM_ATTR forgePacket(iohcPacket* packet, const std::vector<uint8_t> &toSen
 bool msgRcvd(IOHC::iohcPacket *iohc) {
     JsonDocument doc;
     doc["type"] = "Unk";
-    memcpy(IOHC::lastFromAddress, iohc->payload.packet.header.source, sizeof(IOHC::lastFromAddress));
+    { IOHC::Address3 _a; memcpy(_a.b, iohc->payload.packet.header.source, 3); IOHC::lastFromAddress.store(_a); }
 #if defined(WEBSERVER)
-    broadcastLastAddress(bytesToHexString(IOHC::lastFromAddress, sizeof(IOHC::lastFromAddress)).c_str());
+    broadcastLastAddress(bytesToHexString(iohc->payload.packet.header.source, sizeof(address)).c_str());
 #endif
     String deviceId =
         bytesToHexString(iohc->payload.packet.header.source,
@@ -388,7 +387,7 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
                 std::vector<uint8_t> challengeAsked;
                 //                    challengeAsked.assign(iohc->payload.packet.msg.variableData.data, iohc->payload.packet.msg.variableData.data + iohc->payload.packet.msg.variableData.size);
                 challengeAsked.assign(iohc->payload.buffer + 9, iohc->payload.buffer + 15);
-                printf("Challenge asked after LastSend Command %2.2X\n", IOHC::lastSendCmd);
+                printf("Challenge asked after LastSend Command %2.2X\n", IOHC::lastSendCmd.load());
                 printf("Challenge asked after Memorized Command %2.2X\n", cozyDevice2W->memorizeSend.memorizedCmd);
 
                 if (Cmd::scanMode) {
@@ -634,48 +633,6 @@ bool publishMsg(IOHC::iohcPacket *iohc) {
     mqttClient.publish((mqtt_discovery_topic + "/sensor/iohc_frame/state").c_str(), 0, false, message.c_str(), messageSize);
 #endif
     return false;
-}
-
-/**
- * @deprecated
- * The function copies data from one `iohcPacket` object to another and stores it in an
- * array, returning true if successful and false if there are not enough buffers available.
- * 
- * @param iohc The `iohc` parameter in the `msgArchive` function is a pointer to an object of type
- * `IOHC::iohcPacket`. This object contains information such as buffer length, frequency, RSSI
- * (Received Signal Strength Indication), and payload data. The function `msgArchive` is
- * 
- * @return The function `msgArchive` returns a boolean value - `true` if the operation is successful
- * and `false` if there is a failure condition detected during the execution of the function.
- */
-bool msgArchive(IOHC::iohcPacket *iohc) {
-    if (radioPackets[nextPacket]) {
-        delete radioPackets[nextPacket];
-        radioPackets[nextPacket] = nullptr;
-    }
-    radioPackets[nextPacket] = new IOHC::iohcPacket;
-    if (!radioPackets[nextPacket]) {
-        Serial.printf("*** Malloc failed!\n");
-        return false;
-    }
-
-    radioPackets[nextPacket]->buffer_length = iohc->buffer_length;
-    radioPackets[nextPacket]->frequency = iohc->frequency;
-    //    radioPackets[nextPacket]->stamp = iohc->stamp;
-    radioPackets[nextPacket]->rssi = iohc->rssi;
-
-    for (uint8_t i = 0; i < iohc->buffer_length; i++)
-        radioPackets[nextPacket]->payload.buffer[i] = iohc->payload.buffer[i];
-
-    nextPacket += 1;
-    Serial.printf("-> %d\r", nextPacket);
-    if (nextPacket >= IOHC_INBOUND_MAX_PACKETS) {
-        nextPacket = IOHC_INBOUND_MAX_PACKETS - 1;
-        Serial.printf("*** Not enough buffers available. Please erase current ones\n");
-        return false;
-    }
-
-    return true;
 }
 
 /**

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -288,7 +288,7 @@ void handleMqttConnect() {
         4096,      // stack
         nullptr,
         1,         // prioriteit laag
-        &s_mqttPostConnectTask,
+        nullptr,   // handle not needed; task clears s_mqttPostConnectTask itself
         tskNO_AFFINITY
     );
     if (result != pdPASS) {
@@ -299,7 +299,7 @@ void handleMqttConnect() {
 }
 
 void connectToMqtt() {
-    if (mqttClient.connected() || mqttStatus == ConnState::Connecting) {
+    if (mqttClient.connected()) {
         return;  // Avoid parallel connection attempts
     }
     if (WiFi.status() != WL_CONNECTED) {

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -22,6 +22,7 @@ TimerHandle_t heartbeatTimer;
 TaskHandle_t s_mqttPostConnectTask = nullptr;
 static portMUX_TYPE s_connectMux = portMUX_INITIALIZER_UNLOCKED;
 const char AVAILABILITY_TOPIC[] = "iown/status";
+const char FREE_MEM_TOPIC[] = "iown/free_mem";
 static const char GATEWAY_ID[] = "MyOpenIO";
 
 void initMqtt() {
@@ -201,6 +202,7 @@ void removeDiscovery(const std::string &id) {
 
 void publishHeartbeat(TimerHandle_t) {
     mqttClient.publish(AVAILABILITY_TOPIC, 0, true, "online");
+    mqttClient.publish(FREE_MEM_TOPIC, 0, true, std::to_string(esp_get_free_heap_size()).c_str());
 }
 
 void publishCoverState(const std::string &id, const char *state) {
@@ -235,9 +237,30 @@ static void publishIohcFrameDiscovery() {
                        0, true, cfg.c_str(), cfgLen);
 }
 
+static void publishFreeMemoryDiscovery() {
+    JsonDocument configDoc;
+    configDoc["name"] = "Free Memory";
+    configDoc["state_topic"] = FREE_MEM_TOPIC;
+    configDoc["unique_id"] = "free_mem";
+    configDoc["unit_of_measurement"] = "B";
+
+    JsonObject device = configDoc["device"].to<JsonObject>();
+    device["identifiers"] = GATEWAY_ID;
+    device["name"] = "My Open IO Gateway";
+    device["manufacturer"] = "Somfy";
+    device["model"] = "IO Blind Bridge";
+    device["sw_version"] = "1.0.0";
+
+    std::string cfg;
+    size_t cfgLen = serializeJson(configDoc, cfg);
+    mqttClient.publish((mqtt_discovery_topic + "/sensor/free_mem/config").c_str(),
+                       0, true, cfg.c_str(), cfgLen);
+}
+
 static void handleMqttConnectImpl() {
     // Discovery van de ‘frame’ sensor eerst, zodat state pub direct een entity heeft
     publishIohcFrameDiscovery();
+    publishFreeMemoryDiscovery();
     const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
     for (const auto &r : remotes) {
         std::string id = bytesToHexString(r.node, sizeof(r.node));

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -28,6 +28,7 @@ void initMqtt() {
     if (!nvs_read_string(NVS_KEY_MQTT_SERVER, mqtt_server)) {
         if (mqtt_server.empty()) {
             Serial.println("MQTT server not set");
+            return; // no need to continue
         } else {
             nvs_write_string(NVS_KEY_MQTT_SERVER, mqtt_server);
         }
@@ -72,7 +73,7 @@ void initMqtt() {
     mqttClient.onConnect(onMqttConnect);
     mqttClient.onDisconnect(onMqttDisconnect);
     mqttClient.onMessage(onMqttMessage);
-    mqttReconnectTimer = xTimerCreate("mqttTimer", pdMS_TO_TICKS(5000), pdFALSE,
+    mqttReconnectTimer = xTimerCreate("mqttTimer", pdMS_TO_TICKS(5000), pdTRUE,
                                       nullptr,
                                       reinterpret_cast<TimerCallbackFunction_t>(connectToMqtt));
     if (WiFi.status() == WL_CONNECTED) {
@@ -301,14 +302,8 @@ void connectToMqtt() {
     if (mqttClient.connected() || mqttStatus == ConnState::Connecting) {
         return;  // Avoid parallel connection attempts
     }
-    if (mqttReconnectTimer) {
-        xTimerStop(mqttReconnectTimer, 0);
-    }
     if (WiFi.status() != WL_CONNECTED) {
         Serial.println("WiFi not connected, delaying MQTT connection");
-        if (mqttReconnectTimer) {
-            xTimerStart(mqttReconnectTimer, pdMS_TO_TICKS(5000));
-        }
         return;
     }
     if (mqtt_server.empty()) {
@@ -357,9 +352,6 @@ void onMqttDisconnect(AsyncMqttClientDisconnectReason reason) {
     addLogMessage(String("Disconnected from MQTT (reason ") + String(static_cast<uint8_t>(reason)) + ")");
     mqttStatus = ConnState::Disconnected;
     updateDisplayStatus();
-    if (WiFi.status() == WL_CONNECTED && mqttReconnectTimer) {
-        xTimerStart(mqttReconnectTimer, 0);
-    }
 }
 
 void mqttFuncHandler(const char *cmd) {

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -214,6 +214,61 @@ void publishCoverPosition(const std::string &id, float position) {
     mqttClient.publish(topic.c_str(), 0, true, buf);
 }
 
+static void publishIohcFrameDiscovery() {
+    JsonDocument configDoc;
+    configDoc["name"] = "IOHC Frame";
+    configDoc["state_topic"] = mqtt_discovery_topic + "/sensor/iohc_frame/state";
+    configDoc["unique_id"] = "iohc_frame";
+    configDoc["json_attributes_topic"] = mqtt_discovery_topic + "/sensor/iohc_frame/state";
+
+    JsonObject device = configDoc["device"].to<JsonObject>();
+    device["identifiers"] = GATEWAY_ID;
+    device["name"] = "My Open IO Gateway";
+    device["manufacturer"] = "Somfy";
+    device["model"] = "IO Blind Bridge";
+    device["sw_version"] = "1.0.0";
+
+    std::string cfg;
+    size_t cfgLen = serializeJson(configDoc, cfg);
+    mqttClient.publish((mqtt_discovery_topic + "/sensor/iohc_frame/config").c_str(),
+                       0, true, cfg.c_str(), cfgLen);
+}
+
+static void handleMqttConnectImpl() {
+    // Discovery van de ‘frame’ sensor eerst, zodat state pub direct een entity heeft
+    publishIohcFrameDiscovery();
+    const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
+    for (const auto &r : remotes) {
+        std::string id = bytesToHexString(r.node, sizeof(r.node));
+        std::string key = bytesToHexString(r.key, sizeof(r.key));
+        std::string name = r.name.empty() ? r.description : r.name;
+        publishDiscovery(id, name, key);
+        publishTravelTimeDiscovery(id, name, key, r.travelTime);
+        //std::string t = "iown/" + id + "/set";
+        //mqttClient.subscribe(t.c_str(), 0);
+        //mqttClient.subscribe(("iown/" + id + "/pair").c_str(), 0);
+        //mqttClient.subscribe(("iown/" + id + "/add").c_str(), 0);
+        //mqttClient.subscribe(("iown/" + id + "/remove").c_str(), 0);
+        //mqttClient.subscribe(("iown/" + id + "/travel_time/set").c_str(), 0);
+        vTaskDelay(pdMS_TO_TICKS(200)); // throttle per device
+    }
+    if (!heartbeatTimer)
+        heartbeatTimer = xTimerCreate("hb", pdMS_TO_TICKS(60000), pdTRUE, nullptr, publishHeartbeat);
+    xTimerStart(heartbeatTimer, 0);
+    publishHeartbeat(nullptr);
+}
+
+
+static void mqttPostConnectTask(void* /*arg*/) {
+    handleMqttConnectImpl();     // oude body van handleMqttConnect()
+
+    taskENTER_CRITICAL(&s_connectMux);
+    s_mqttPostConnectTask = nullptr;
+    taskEXIT_CRITICAL(&s_connectMux);
+
+    vTaskDelete(nullptr);
+}
+
 // ==== BELANGRIJK: scheduler die het zware werk in een eigen task zet ====
 void handleMqttConnect() {
     if (mqttStatus != ConnState::Connected) return;
@@ -240,40 +295,6 @@ void handleMqttConnect() {
         s_mqttPostConnectTask = nullptr;
         taskEXIT_CRITICAL(&s_connectMux);
     }
-}
-
-static void mqttPostConnectTask(void* /*arg*/) {
-    handleMqttConnectImpl();     // oude body van handleMqttConnect()
-
-    taskENTER_CRITICAL(&s_connectMux);
-    s_mqttPostConnectTask = nullptr;
-    taskEXIT_CRITICAL(&s_connectMux);
-
-    vTaskDelete(nullptr);
-}
-
-static void handleMqttConnectImpl() {
-    // Discovery van de ‘frame’ sensor eerst, zodat state pub direct een entity heeft
-    publishIohcFrameDiscovery();
-    const auto &remotes = IOHC::iohcRemote1W::getInstance()->getRemotes();
-    for (const auto &r : remotes) {
-        std::string id = bytesToHexString(r.node, sizeof(r.node));
-        std::string key = bytesToHexString(r.key, sizeof(r.key));
-        std::string name = r.name.empty() ? r.description : r.name;
-        publishDiscovery(id, name, key);
-        publishTravelTimeDiscovery(id, name, key, r.travelTime);
-        //std::string t = "iown/" + id + "/set";
-        //mqttClient.subscribe(t.c_str(), 0);
-        //mqttClient.subscribe(("iown/" + id + "/pair").c_str(), 0);
-        //mqttClient.subscribe(("iown/" + id + "/add").c_str(), 0);
-        //mqttClient.subscribe(("iown/" + id + "/remove").c_str(), 0);
-        //mqttClient.subscribe(("iown/" + id + "/travel_time/set").c_str(), 0);
-        vTaskDelay(pdMS_TO_TICKS(200)); // throttle per device
-    }
-    if (!heartbeatTimer)
-        heartbeatTimer = xTimerCreate("hb", pdMS_TO_TICKS(60000), pdTRUE, nullptr, publishHeartbeat);
-    xTimerStart(heartbeatTimer, 0);
-    publishHeartbeat(nullptr);
 }
 
 void connectToMqtt() {
@@ -340,27 +361,6 @@ void onMqttDisconnect(AsyncMqttClientDisconnectReason reason) {
         xTimerStart(mqttReconnectTimer, 0);
     }
 }
-
-static void publishIohcFrameDiscovery() {
-    JsonDocument configDoc;
-    configDoc["name"] = "IOHC Frame";
-    configDoc["state_topic"] = mqtt_discovery_topic + "/sensor/iohc_frame/state";
-    configDoc["unique_id"] = "iohc_frame";
-    configDoc["json_attributes_topic"] = mqtt_discovery_topic + "/sensor/iohc_frame/state";
-
-    JsonObject device = configDoc["device"].to<JsonObject>();
-    device["identifiers"] = GATEWAY_ID;
-    device["name"] = "My Open IO Gateway";
-    device["manufacturer"] = "Somfy";
-    device["model"] = "IO Blind Bridge";
-    device["sw_version"] = "1.0.0";
-
-    std::string cfg;
-    size_t cfgLen = serializeJson(configDoc, cfg);
-    mqttClient.publish((mqtt_discovery_topic + "/sensor/iohc_frame/config").c_str(),
-                       0, true, cfg.c_str(), cfgLen);
-}
-
 
 void mqttFuncHandler(const char *cmd) {
     constexpr char delim = ' ';

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -19,6 +19,8 @@
 AsyncMqttClient mqttClient;
 TimerHandle_t mqttReconnectTimer;
 TimerHandle_t heartbeatTimer;
+TaskHandle_t s_mqttPostConnectTask = nullptr;
+static portMUX_TYPE s_connectMux = portMUX_INITIALIZER_UNLOCKED;
 const char AVAILABILITY_TOPIC[] = "iown/status";
 static const char GATEWAY_ID[] = "MyOpenIO";
 
@@ -215,8 +217,16 @@ void publishCoverPosition(const std::string &id, float position) {
 // ==== BELANGRIJK: scheduler die het zware werk in een eigen task zet ====
 void handleMqttConnect() {
     if (mqttStatus != ConnState::Connected) return;
-    if (s_mqttPostConnectTask) return; // al bezig
-    xTaskCreatePinnedToCore(
+
+    taskENTER_CRITICAL(&s_connectMux);
+    bool shouldSpawn = (s_mqttPostConnectTask == nullptr);
+    if (shouldSpawn)
+        s_mqttPostConnectTask = (TaskHandle_t)1; // placeholder to block re-entry
+    taskEXIT_CRITICAL(&s_connectMux);
+
+    if (!shouldSpawn) return;
+
+    BaseType_t result = xTaskCreatePinnedToCore(
         mqttPostConnectTask,
         "mqttPostConnect",
         4096,      // stack
@@ -225,11 +235,20 @@ void handleMqttConnect() {
         &s_mqttPostConnectTask,
         tskNO_AFFINITY
     );
+    if (result != pdPASS) {
+        taskENTER_CRITICAL(&s_connectMux);
+        s_mqttPostConnectTask = nullptr;
+        taskEXIT_CRITICAL(&s_connectMux);
+    }
 }
 
 static void mqttPostConnectTask(void* /*arg*/) {
     handleMqttConnectImpl();     // oude body van handleMqttConnect()
+
+    taskENTER_CRITICAL(&s_connectMux);
     s_mqttPostConnectTask = nullptr;
+    taskEXIT_CRITICAL(&s_connectMux);
+
     vTaskDelete(nullptr);
 }
 

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -77,6 +77,7 @@ void initMqtt() {
     mqttReconnectTimer = xTimerCreate("mqttTimer", pdMS_TO_TICKS(5000), pdTRUE,
                                       nullptr,
                                       reinterpret_cast<TimerCallbackFunction_t>(connectToMqtt));
+    xTimerStart(mqttReconnectTimer, 0);
     if (WiFi.status() == WL_CONNECTED) {
         connectToMqtt();
     }
@@ -399,15 +400,12 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
                    size_t len, size_t index, size_t total) {
     if (!topic || !payload || len == 0) return;
 
-    // Safe copy of payload
-    char buf[len + 1];
-    memcpy(buf, payload, len);
-    buf[len] = '\0';
+    // Safe copy of payload — use std::string to avoid VLA stack overflow on large payloads
+    std::string payloadStr(payload, len);
 
-    Serial.printf("Received MQTT %s %s %d\n", topic, buf, len);
+    Serial.printf("Received MQTT %s %s %d\n", topic, payloadStr.c_str(), len);
 
     std::string topicStr(topic);
-    std::string payloadStr(buf);
 
     if (topicStr.rfind("iown/", 0) == 0 && topicStr.find("/travel_time/set", 5) != std::string::npos) {
         std::string id = topicStr.substr(5, topicStr.find("/travel_time/set", 5) - 5);
@@ -570,7 +568,7 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
     }
 
     JsonDocument doc;
-    DeserializationError error = deserializeJson(doc, buf);
+    DeserializationError error = deserializeJson(doc, payloadStr);
     if (error) {
         Serial.print("Failed to parse JSON: ");
         Serial.println(error.c_str());
@@ -578,12 +576,8 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
     }
 
     const char *data = doc["_data"];
-    size_t bufferSize = strlen(topic) + (data ? strlen(data) : 0) + 7;
-    char message[bufferSize];
-    if (!data)
-        snprintf(message, sizeof(message), "MQTT %s", topic);
-    else
-        snprintf(message, sizeof(message), "MQTT %s %s", topic, data);
-    mqttFuncHandler(message);
+    std::string message = data ? (std::string("MQTT ") + topic + " " + data)
+                               : (std::string("MQTT ") + topic);
+    mqttFuncHandler(message.c_str());
 }
 #endif // MQTT

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -555,8 +555,10 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
     }
 
     JsonDocument doc;
-    if (deserializeJson(doc, buf) != DeserializationError::Ok) {
-        Serial.println(F("Failed to parse JSON"));
+    DeserializationError error = deserializeJson(doc, buf);
+    if (error) {
+        Serial.print("Failed to parse JSON: ");
+        Serial.println(error.c_str());
         return;
     }
 

--- a/src/oled_display.cpp
+++ b/src/oled_display.cpp
@@ -24,9 +24,11 @@
 #include <WiFi.h>
 #include <display_helpers.h>
 #include <chrono>
+#include <freertos/semphr.h>
 
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RST);
 DisplayBuffer displayBuffer;
+SemaphoreHandle_t displayBufferMutex = xSemaphoreCreateMutex();
 TimerHandle_t displayUpdateTimer;
 std::chrono::time_point<std::chrono::system_clock> startTime;
 std::chrono::time_point<std::chrono::system_clock> timeSinceNoData;
@@ -190,13 +192,17 @@ const char* getRemoteName(const uint8_t *remote, const char *name) {
 }
 
 void display1WAction(const uint8_t *remote, const char *action, const char *dir, const char *name) {
+    xSemaphoreTake(displayBufferMutex, portMAX_DELAY);
     displayBuffer.addLine(format("%s: %s", dir, getRemoteName(remote, name)), action);
+    xSemaphoreGive(displayBufferMutex);
 
     setTimerSpeed(fast);
 }
 
 void display1WPosition(const uint8_t *remote, float position, const char *name) {
+    xSemaphoreTake(displayBufferMutex, portMAX_DELAY);
     displayBuffer.addLine(getRemoteName(remote, name), format("%d%%", static_cast<int>(position)));
+    xSemaphoreGive(displayBufferMutex);
 
     setTimerSpeed(fast);
 }
@@ -242,7 +248,9 @@ bool drawContents() {
     const int width = SCREEN_WIDTH / 6; // char width is 5 + 1 pixel space
     const int height = (SCREEN_HEIGHT - 20 - 8) / 8; // char height is 7 + 1 pixel space and 20 pixels (12 pixels + an empty line) for the header + 8 for the footer
 
+    xSemaphoreTake(displayBufferMutex, portMAX_DELAY);
     const auto lines = displayBuffer.getTextToDisplay(width, height);
+    xSemaphoreGive(displayBufferMutex);
     for(auto &line : lines) {
         display.println(line.c_str());
     }

--- a/src/oled_display.cpp
+++ b/src/oled_display.cpp
@@ -23,7 +23,9 @@
 #include <wifi_helper.h>
 #include <WiFi.h>
 #include <display_helpers.h>
+#include <atomic>
 #include <chrono>
+#include <esp_timer.h>
 #include <freertos/semphr.h>
 
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RST);
@@ -31,7 +33,7 @@ DisplayBuffer displayBuffer;
 SemaphoreHandle_t displayBufferMutex = xSemaphoreCreateMutex();
 TimerHandle_t displayUpdateTimer;
 std::chrono::time_point<std::chrono::system_clock> startTime;
-std::chrono::time_point<std::chrono::system_clock> timeSinceNoData;
+std::atomic<int64_t> lastDataTime = 0;
 void handleTimerTick(TimerHandle_t);
 
 const int MILLIS_BETWEEN_DISPLAY_UPDATE_SLOW = 5000;
@@ -129,7 +131,7 @@ int mqttStatusToIconIndex() {
 
 const bool fast = true;
 const bool slow = false;
-bool timerIsFast = false;
+std::atomic<bool> timerIsFast = false;
 void setTimerSpeed(bool needsFast) {
     if (needsFast != timerIsFast) {
         xTimerChangePeriod(displayUpdateTimer, pdMS_TO_TICKS(needsFast ? MILLIS_BETWEEN_DISPLAY_UPDATE_FAST : MILLIS_BETWEEN_DISPLAY_UPDATE_SLOW), 0);
@@ -145,7 +147,7 @@ bool initDisplay() {
     }
 
     startTime = std::chrono::system_clock::now();
-    timeSinceNoData = startTime;
+    lastDataTime = esp_timer_get_time();
     displayUpdateTimer = xTimerCreate(
         "displayTimer",
         pdMS_TO_TICKS(MILLIS_BETWEEN_DISPLAY_UPDATE_FAST),
@@ -171,7 +173,7 @@ int getSecondsSinceStart() {
 }
 
 int getSecondsSinceNoData() {
-    return getSecondsSince(timeSinceNoData);
+    return (esp_timer_get_time() - lastDataTime.load()) / 1000000LL;
 }
 
 template<typename ... Args>
@@ -196,6 +198,7 @@ void display1WAction(const uint8_t *remote, const char *action, const char *dir,
     displayBuffer.addLine(format("%s: %s", dir, getRemoteName(remote, name)), action);
     xSemaphoreGive(displayBufferMutex);
 
+    lastDataTime.store(esp_timer_get_time());
     setTimerSpeed(fast);
 }
 
@@ -204,10 +207,13 @@ void display1WPosition(const uint8_t *remote, float position, const char *name) 
     displayBuffer.addLine(getRemoteName(remote, name), format("%d%%", static_cast<int>(position)));
     xSemaphoreGive(displayBufferMutex);
 
+    lastDataTime.store(esp_timer_get_time());
     setTimerSpeed(fast);
 }
 
 void updateDisplayStatus() {
+    lastDataTime.store(esp_timer_get_time());
+
     setTimerSpeed(fast);
 }
 
@@ -260,7 +266,6 @@ bool drawContents() {
 void handleTimerTick(TimerHandle_t) {
     display.clearDisplay();
 
-    timeSinceNoData = timerIsFast ? std::chrono::system_clock::now() : timeSinceNoData;
     const auto secondsSinceNoData = getSecondsSinceNoData();
 
     if (timerIsFast || secondsSinceNoData < SECONDS_BEFORE_SCREENSAVER) {

--- a/src/web_server_handler.cpp
+++ b/src/web_server_handler.cpp
@@ -401,7 +401,8 @@ void handleApiLogs(AsyncWebServerRequest *request, JsonArray &root) {
 }
 
 void handleApiLastAddr(AsyncWebServerRequest *request, JsonObject &root) {
-  root["address"] = bytesToHexString(IOHC::lastFromAddress, sizeof(IOHC::lastFromAddress)).c_str();
+  const auto _a = IOHC::lastFromAddress.load();
+  root["address"] = bytesToHexString(_a.b, sizeof(_a.b)).c_str();
 }
 
 #if defined(SYSLOG)

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -103,15 +103,9 @@ void checkWifiConnection() {
             wifiStatus = { ConnState::Disconnected, 0 };
             updateDisplayStatus();
 
-#if defined(MQTT)
-            Serial.println("Stopping MQTT reconnect timer");
-            if (mqttReconnectTimer) {
-                xTimerStop(mqttReconnectTimer, 0);
-            }
-#endif
             if (wifiReconnectTimer) {
                 xTimerStart(wifiReconnectTimer, 0);
-            }
-        }
+            }   
+        }     
     }
 }

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -17,6 +17,7 @@
 #include <wifi_helper.h>
 #include <oled_display.h>
 #include <user_config.h>
+#include <esp_wifi.h>
 #if defined(MQTT)
 #include <mqtt_handler.h>
 #endif
@@ -24,88 +25,231 @@
 #include <ESPmDNS.h>
 
 TimerHandle_t wifiReconnectTimer;
-
 WiFiStatus wifiStatus = { ConnState::Disconnected, 0 };
 
+static TaskHandle_t s_wifiTaskHandle = nullptr;
+static bool s_portalNeeded = false; // true only on first boot if no credentials exist
+static TimerHandle_t s_rssiTimer = nullptr;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// Replicate WiFiManager::getRSSIasQuality() without constructing a WiFiManager object.
+static int rssiToQuality(int rssi) {
+    if (rssi <= -100) return 0;
+    if (rssi >= -50)  return 100;
+    return 2 * (rssi + 100);
+}
+
+static void rssiTimerCb(TimerHandle_t) {
+    if (WiFi.status() == WL_CONNECTED) {
+        wifiStatus.signalStrengthPercent = rssiToQuality(WiFi.RSSI());
+    }
+}
+
+static void onMqttAfterWifi() {
+#if defined(MQTT)
+    if (mqttReconnectTimer && !mqttClient.connected() &&
+        mqttStatus != ConnState::Connecting) {
+        connectToMqtt();
+    }
+#endif
+}
+
+static void wifiConnectTask(void * /*arg*/) {
+    for (;;) {
+        // Wait for notification from timer callback or WiFi event handler
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+
+        // The auto-reconnect may have already restored the connection by the time
+        // this task runs (race between the reconnect timer and the GOT_IP event).
+        // If we're already connected, just ensure MQTT is up and do nothing else.
+        if (WiFi.status() == WL_CONNECTED) {
+            Serial.println("WiFi: connect task woken but already connected, skipping");
+            wifiStatus = { ConnState::Connected, rssiToQuality(WiFi.RSSI()) };
+            updateDisplayStatus();
+            onMqttAfterWifi();
+            continue;
+        }
+
+        Serial.println("WiFi: connect task woken, attempting connection...");
+        wifiStatus = { ConnState::Connecting, 0 };
+        updateDisplayStatus();
+
+        // Try the stored credentials quickly first
+        WiFi.mode(WIFI_STA);
+        WiFi.begin();
+
+        wl_status_t result = static_cast<wl_status_t>(WiFi.waitForConnectResult(10000UL));
+
+        if (result == WL_CONNECTED) {
+            Serial.printf("WiFi: connected, IP=%s RSSI=%d\n",
+                          WiFi.localIP().toString().c_str(), WiFi.RSSI());
+            wifiStatus = { ConnState::Connected, rssiToQuality(WiFi.RSSI()) };
+            updateDisplayStatus();
+
+            if (!MDNS.begin("miopenio")) {
+                Serial.println("WiFi: mDNS start failed");
+            } else {
+                Serial.println("WiFi: mDNS started at http://miopenio.local");
+            }
+
+            onMqttAfterWifi();
+
+        } else if (s_portalNeeded) {
+            // First boot with no valid credentials — open the captive portal once
+            Serial.println("WiFi: no stored credentials, launching WiFiManager portal");
+            WiFiManager wm;
+            wm.setConnectTimeout(30);
+            wm.setConfigPortalTimeout(180);
+            bool ok = wm.autoConnect("iohc-setup");
+            s_portalNeeded = false; // never open again after this attempt
+
+            if (ok) {
+                Serial.printf("WiFi: portal success, IP=%s\n",
+                              WiFi.localIP().toString().c_str());
+                wifiStatus = { ConnState::Connected, rssiToQuality(WiFi.RSSI()) };
+                updateDisplayStatus();
+
+                if (!MDNS.begin("miopenio")) {
+                    Serial.println("WiFi: mDNS start failed");
+                } else {
+                    Serial.println("WiFi: mDNS started at http://miopenio.local");
+                }
+
+                onMqttAfterWifi();
+            } else {
+                Serial.println("WiFi: portal timed out, will retry");
+                wifiStatus = { ConnState::Disconnected, 0 };
+                updateDisplayStatus();
+                if (wifiReconnectTimer) xTimerStart(wifiReconnectTimer, 0);
+            }
+
+        } else {
+            // Reconnect attempt after a dropout — just retry later, no portal
+            Serial.printf("WiFi: reconnect failed (status=%d), will retry in 10s\n",
+                          static_cast<int>(result));
+            wifiStatus = { ConnState::Disconnected, 0 };
+            updateDisplayStatus();
+            if (wifiReconnectTimer) xTimerStart(wifiReconnectTimer, 0);
+        }
+    }
+}
+
+// Timer callback — must not block; just wake the task
+static void wifiReconnectTimerCb(TimerHandle_t) {
+    if (s_wifiTaskHandle) xTaskNotifyGive(s_wifiTaskHandle);
+}
+
+// ---------------------------------------------------------------------------
+// WiFi event handler — instant detection, no polling required
+// ---------------------------------------------------------------------------
+
+static void onWifiEvent(WiFiEvent_t event) {
+    switch (event) {
+        case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
+            if (wifiStatus.connectionStatus == ConnState::Connected) {
+                Serial.println("WiFi: connection lost (event)");
+                wifiStatus = { ConnState::Disconnected, 0 };
+                updateDisplayStatus();
+                // Kick reconnect task after 10 s
+                if (wifiReconnectTimer) xTimerStart(wifiReconnectTimer, 0);
+            }
+            break;
+
+        case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+            // The ESP32 driver reconnected autonomously (setAutoReconnect default)
+            if (wifiStatus.connectionStatus != ConnState::Connected) {
+                Serial.printf("WiFi: auto-recovered, IP=%s\n",
+                              WiFi.localIP().toString().c_str());
+                wifiStatus = { ConnState::Connected, rssiToQuality(WiFi.RSSI()) };
+                updateDisplayStatus();
+                // Stop any pending reconnect timer — we're already back
+                if (wifiReconnectTimer) xTimerStop(wifiReconnectTimer, 0);
+                onMqttAfterWifi();
+            }
+            break;
+
+        default:
+            break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 void initWifi() {
+    // Set hostname before the WiFi stack initialises so the DHCP client
+    // advertises the correct name from the very first connection attempt,
+    // including after auto-reconnects where the connect task never runs.
+    WiFi.setHostname("MiOpenIO");
+
+    // Detect whether we have stored credentials; if not, portal is needed on first attempt
+    wifi_config_t conf;
+    esp_wifi_get_config(WIFI_IF_STA, &conf);
+    s_portalNeeded = (conf.sta.ssid[0] == '\0');
+
+    WiFi.onEvent(onWifiEvent);
+
     wifiReconnectTimer = xTimerCreate(
         "wifiTimer",
-        pdMS_TO_TICKS(10000),  // 10 seconds retry interval
-        pdFALSE,
+        pdMS_TO_TICKS(10000),
+        pdFALSE,          // one-shot; restarted explicitly when needed
         nullptr,
-        connectToWifi
+        wifiReconnectTimerCb
     );
     if (!wifiReconnectTimer) {
-        Serial.println("Failed to create WiFi reconnect timer");
+        Serial.println("WiFi: failed to create reconnect timer");
     }
-    connectToWifi(nullptr);
+
+    // Create the dedicated WiFi task so blocking calls never run in the timer task
+    xTaskCreatePinnedToCore(
+        wifiConnectTask,
+        "wifiConnect",
+        4096,
+        nullptr,
+        2,               // priority just above loop() (1), below radio ISR task (4)
+        &s_wifiTaskHandle,
+        tskNO_AFFINITY
+    );
+
+    // Periodically refresh the RSSI reading for the signal-strength display
+    s_rssiTimer = xTimerCreate("rssiTimer", pdMS_TO_TICKS(5000), pdTRUE,
+                               nullptr, rssiTimerCb);
+    if (s_rssiTimer) xTimerStart(s_rssiTimer, 0);
+
+    // Kick the initial connection attempt
+    if (s_wifiTaskHandle) xTaskNotifyGive(s_wifiTaskHandle);
 }
 
 void connectToWifi(TimerHandle_t /*timer*/) {
-    Serial.println("Connecting to Wi-Fi...");
-    wifiStatus = { ConnState::Connecting, 0 };
-
-    updateDisplayStatus();
-
-    WiFi.mode(WIFI_STA);
-    WiFi.setHostname("MIOPENIO");
-
-    unsigned long startTime = millis();
-    WiFi.begin();
-    wl_status_t result = static_cast<wl_status_t>(WiFi.waitForConnectResult(5000UL)); // ms
-
-    WiFiManager wm;
-    wm.setConnectTimeout(30);        // 10 sec voor verbinding met AP
-    wm.setConfigPortalTimeout(180);  // 3 min captive portal open
-
-    bool res = false;
-    if (result == WL_CONNECTED) {
-        res = true;
-    } else {
-        Serial.println("Stored WiFi credentials failed, launching WiFiManager portal");
-        res = wm.autoConnect("iohc-setup");
-    }
-
-    unsigned long duration = millis() - startTime;
-
-    if (!res) {
-        Serial.printf("WiFi connection failed after %lu ms\n", duration);
-        wifiStatus = { ConnState::Disconnected, 0 };
-
-        // Retry later
-        if (wifiReconnectTimer) {
-            xTimerStart(wifiReconnectTimer, 0);
-        }
-    } else {
-        Serial.printf("Connected to WiFi in %lu ms. IP address: %s\n", duration,
-                      WiFi.localIP().toString().c_str());
-        wifiStatus = { ConnState::Connected, wm.getRSSIasQuality(WiFi.RSSI()) };
-
-        if (!MDNS.begin("miopenio")) {
-            Serial.println("Error setting up MDNS responder!");
-        } else {
-            Serial.println("MDNS responder started at http://miopenio.local");
-        }
-#if defined(MQTT)
-        // Establish MQTT connection if needed and MQTT client is initialized
-        if (mqttReconnectTimer && !mqttClient.connected() &&
-            mqttStatus != ConnState::Connecting) {
-            connectToMqtt();
-        }
-#endif
-    }
+    // Legacy call-site compatibility (called from connectToWifi(nullptr) pattern).
+    // Simply wake the task.
+    if (s_wifiTaskHandle) xTaskNotifyGive(s_wifiTaskHandle);
 }
 
 void checkWifiConnection() {
-    if (WiFi.status() != WL_CONNECTED) {
-        if (wifiStatus.connectionStatus == ConnState::Connected) {
-            Serial.println("WiFi connection lost");
-            wifiStatus = { ConnState::Disconnected, 0 };
-            updateDisplayStatus();
+    // Still polled from loop() as a safety net for cases the event handler misses.
+    // Detect both loss AND autonomous recovery.
+    wl_status_t status = static_cast<wl_status_t>(WiFi.status());
 
-            if (wifiReconnectTimer) {
-                xTimerStart(wifiReconnectTimer, 0);
-            }   
-        }     
+    if (status != WL_CONNECTED &&
+        wifiStatus.connectionStatus == ConnState::Connected) {
+        // Missed disconnect event
+        Serial.println("WiFi: loss detected by poll");
+        wifiStatus = { ConnState::Disconnected, 0 };
+        updateDisplayStatus();
+        if (wifiReconnectTimer) xTimerStart(wifiReconnectTimer, 0);
+    } else if (status == WL_CONNECTED &&
+               wifiStatus.connectionStatus != ConnState::Connected) {
+        // Autonomous recovery detected by poll (event handler already handles this,
+        // but this is a belt-and-suspenders fallback)
+        Serial.println("WiFi: recovery detected by poll");
+        wifiStatus = { ConnState::Connected, rssiToQuality(WiFi.RSSI()) };
+        updateDisplayStatus();
+        if (wifiReconnectTimer) xTimerStop(wifiReconnectTimer, 0);
+        onMqttAfterWifi();
     }
 }

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -80,6 +80,20 @@ static void wifiConnectTask(void * /*arg*/) {
         // ensure to have all channels available so it connects to the AP with strongest signal if you have multiple with the same name
         WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN); 
 
+        // safety measures
+        wifi_config_t conf;
+        if (esp_wifi_get_config(WIFI_IF_STA, &conf) == ESP_OK) {
+#ifdef REQUIRE_MINIMUM_WPA2_PSK  
+            // This is necessary to prevent the device from Evil Twin attacks, where an attacker creates an additional network with the same
+            // SSID as the one selected. WPA2_PSK will detect that and even prevent sending the password. 
+
+            // Enable minimal WPA2_PSK level (also allows WPA3 or other more secure modes)
+            conf.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
+#else
+            conf.sta.threshold.authmode = WIFI_AUTH_OPEN;
+#endif
+            esp_wifi_set_config(WIFI_IF_STA, &conf);
+        }
 
         // Try the stored credentials quickly first
         WiFi.mode(WIFI_STA);
@@ -225,12 +239,6 @@ void initWifi() {
     if (s_rssiTimer) xTimerStart(s_rssiTimer, 0);
 
     // Kick the initial connection attempt
-    if (s_wifiTaskHandle) xTaskNotifyGive(s_wifiTaskHandle);
-}
-
-void connectToWifi(TimerHandle_t /*timer*/) {
-    // Legacy call-site compatibility (called from connectToWifi(nullptr) pattern).
-    // Simply wake the task.
     if (s_wifiTaskHandle) xTaskNotifyGive(s_wifiTaskHandle);
 }
 

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -77,6 +77,10 @@ static void wifiConnectTask(void * /*arg*/) {
         wifiStatus = { ConnState::Connecting, 0 };
         updateDisplayStatus();
 
+        // ensure to have all channels available so it connects to the AP with strongest signal if you have multiple with the same name
+        WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN); 
+
+
         // Try the stored credentials quickly first
         WiFi.mode(WIFI_STA);
         WiFi.begin();


### PR DESCRIPTION
I've done some investigations to try to avoid memory leaks. I also fixed a lot of threading issues that can occur when things are accessed concurrently. Next to that a couple of potential buffer overflow or underflow issues are prevented.

One approach I applied is to use less field members in favor of local variables. Notable mentions here are the `packets2send` in the device implementations and the `iohc` member in the `iohcRadio` class. Using local variables avoids the risk or confusion that several methods influence each-other or overwrite stuff of each-other. That could lead to memory leaks or unexpected behaviors. Local variables also simplify code as you know when they are created and when they have to be freed.

I've simplified `iohcRadio` a lot in order to improve the code there. It now should be possible to have home assistant send open/close requests to a list of cover devices at once without those interrupting each other (there should be no need to send them with some delay in between anymore). 