### PR TITLE
WiFi and Display improvements (thread safety, stability)

### DIFF
--- a/include/display_helpers.h
+++ b/include/display_helpers.h
@@ -50,12 +50,13 @@ class DisplayBuffer {
         ScrollingWindow scroller;
 
         Line* find(const std::string key);
+        void purge();
     public:
         DisplayBuffer();
     
         void addLine(const std::string &leftText, const std::string &rightText = "");
 
-        void purge();
+        void clear();
 
         std::vector<std::string> getTextToDisplay(const int width, const int height);
 };

--- a/include/interact.h
+++ b/include/interact.h
@@ -53,7 +53,7 @@ namespace IOHC {
 
 #if defined(ESP32)
   #include <TickerUsESP32.h>
-  #define MAXCMDS 50
+  #define MAXCMDS 100
 #endif
 
 enum class ConnState { Connecting, Connected, Disconnected };

--- a/include/mqtt_handler.h
+++ b/include/mqtt_handler.h
@@ -12,8 +12,6 @@
 #include <ArduinoJson.h>
 
 extern AsyncMqttClient mqttClient;
-extern TimerHandle_t mqttReconnectTimer;
-extern TimerHandle_t heartbeatTimer;
 extern const char AVAILABILITY_TOPIC[];
 
 void initMqtt();
@@ -28,7 +26,7 @@ void publishDiscovery(const std::string &id, const std::string &name, const std:
 void publishTravelTimeDiscovery(const std::string &id, const std::string &name,
                                 const std::string &key, uint32_t travelTime);
 void handleMqttConnect();
-void publishHeartbeat(TimerHandle_t timer);
+void publishHeartbeat();
 void mqttFuncHandler(const char *cmd);
 void publishCoverState(const std::string &id, const char *state);
 void publishCoverPosition(const std::string &id, float position);
@@ -40,4 +38,3 @@ static void handleMqttConnectImpl();
 #endif // MQTT
 
 #endif // MQTT_HANDLER_H
-

--- a/include/oled_display.h
+++ b/include/oled_display.h
@@ -23,11 +23,25 @@ extern Adafruit_SSD1306 display;
 bool initDisplay();
 void display1WAction(const uint8_t *remote, const char *action, const char *dir, const char *name = nullptr);
 void display1WPosition(const uint8_t *remote, float position, const char *name = nullptr);
+void displayCustomMessage(const char* message, const char* status = nullptr);
+void clearDisplayMessages();
 void updateDisplayStatus();
 #else
 inline bool initDisplay() { return true; }
 inline void display1WAction(const uint8_t *, const char *, const char *, const char * = nullptr) {}
 inline void updateDisplayStatus() {}
+inline void displayCustomMessage(const char*, const char* = nullptr) {}
+inline void clearDisplayMessages() {}
 #endif
+
+
+template<typename ... Args>
+std::string format(const std::string &format, Args ... args)
+{
+    char buf[250];
+    snprintf(buf, 250, format.c_str(), args ...);
+    return std::string(buf);
+}
+
 
 #endif // OLED_DISPLAY_H

--- a/include/wifi_helper.h
+++ b/include/wifi_helper.h
@@ -20,16 +20,14 @@
 #include <interact.h>
 #include <WiFi.h>
 #include <WiFiManager.h>
+#include <atomic>
 
-extern TimerHandle_t wifiReconnectTimer;
 extern struct WiFiStatus {
-  ConnState connectionStatus;
-  int signalStrengthPercent;
+  std::atomic<ConnState> connectionStatus;
+  std::atomic<int> signalStrengthPercent;
 } wifiStatus;
 
 
 void initWifi();
-void connectToWifi(TimerHandle_t timer = nullptr);
-void checkWifiConnection();
 
 #endif // WIFI_HELPER_H

--- a/include/wifi_helper.h
+++ b/include/wifi_helper.h
@@ -29,5 +29,6 @@ extern struct WiFiStatus {
 
 
 void initWifi();
+void clearWifi();
 
 #endif // WIFI_HELPER_H

--- a/src/display_helpers.cpp
+++ b/src/display_helpers.cpp
@@ -104,6 +104,10 @@ void DisplayBuffer::purge() {
     lines = newLines;
 }
 
+void DisplayBuffer::clear() {
+    lines.clear();
+}
+
 std::vector<std::string> DisplayBuffer::getTextToDisplay(const int width, const int height) {
     purge();
 

--- a/src/interact.cpp
+++ b/src/interact.cpp
@@ -394,6 +394,9 @@ void createCommands() {
             handleMqttConnect();
     });
 #endif
+    Cmd::addHandler((char *) "wifiClear", (char *) "Clear configured WiFi settings and restart device", [](Tokens *cmd)-> void {
+        clearWifi();
+    });
 /*
     Cmd::addHandler((char *) "list2W", (char *) "List received packets", [](Tokens *cmd)-> void {
         for (uint8_t i = 0; i < nextPacket; i++) msgRcvd(radioPackets[i]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,9 +146,6 @@ void setup() {
 #if defined(MQTT)
     initMqtt();
 #endif
-#if defined(WEBSERVER)
-    setupWebServer();
-#endif
     Cmd::kbd_tick.attach_ms(500, Cmd::cmdFuncHandler);
 
 //    esp_timer_dump(stdout);
@@ -725,5 +722,4 @@ void txUserBuffer(Tokens *cmd) {
 
 void loop() {
     loopWebServer(); // For ESPAsyncWebServer, this is typically not needed.
-    checkWifiConnection();
 }

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -15,12 +15,27 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <nvs_helpers.h>
+#include <atomic>
 
 AsyncMqttClient mqttClient;
-TimerHandle_t mqttReconnectTimer;
-TimerHandle_t heartbeatTimer;
 const char AVAILABILITY_TOPIC[] = "iown/status";
 static const char GATEWAY_ID[] = "MyOpenIO";
+static TaskHandle_t s_mqttSchedulerTask = nullptr;
+static std::atomic<bool> s_heartbeatEnabled{false};
+static std::atomic<uint32_t> s_nextHeartbeatAtMs{0};
+static uint32_t s_lastMqttConnectAttemptMs = 0;
+static constexpr uint32_t MQTT_RECONNECT_INTERVAL_MS = 5000;
+
+static void mqttSchedulerTask(void*);
+
+static void startHeartbeat() {
+    s_heartbeatEnabled.store(true);
+    s_nextHeartbeatAtMs.store(millis() + 60000UL);
+}
+
+static void stopHeartbeat() {
+    s_heartbeatEnabled.store(false);
+}
 
 void initMqtt() {
     if (!nvs_read_string(NVS_KEY_MQTT_SERVER, mqtt_server)) {
@@ -70,9 +85,14 @@ void initMqtt() {
     mqttClient.onConnect(onMqttConnect);
     mqttClient.onDisconnect(onMqttDisconnect);
     mqttClient.onMessage(onMqttMessage);
-    mqttReconnectTimer = xTimerCreate("mqttTimer", pdMS_TO_TICKS(5000), pdFALSE,
-                                      nullptr,
-                                      reinterpret_cast<TimerCallbackFunction_t>(connectToMqtt));
+
+    if (xTaskCreatePinnedToCore(mqttSchedulerTask, "mqttScheduler", 4096, nullptr,
+                                1, &s_mqttSchedulerTask, tskNO_AFFINITY) != pdPASS) {
+        Serial.println("Failed to create MQTT scheduler task");
+        s_mqttSchedulerTask = nullptr;
+        return;
+    }
+
     if (WiFi.status() == WL_CONNECTED) {
         connectToMqtt();
     }
@@ -196,7 +216,7 @@ void removeDiscovery(const std::string &id) {
     mqttClient.publish(t.c_str(), 0, true, "", 0);
 }
 
-void publishHeartbeat(TimerHandle_t) {
+void publishHeartbeat() {
     mqttClient.publish(AVAILABILITY_TOPIC, 0, true, "online");
 }
 
@@ -251,30 +271,23 @@ static void handleMqttConnectImpl() {
         //mqttClient.subscribe(("iown/" + id + "/travel_time/set").c_str(), 0);
         vTaskDelay(pdMS_TO_TICKS(200)); // throttle per device
     }
-    if (!heartbeatTimer)
-        heartbeatTimer = xTimerCreate("hb", pdMS_TO_TICKS(60000), pdTRUE, nullptr, publishHeartbeat);
-    xTimerStart(heartbeatTimer, 0);
-    publishHeartbeat(nullptr);
+    startHeartbeat();
+    publishHeartbeat();
 }
 
 void connectToMqtt() {
     if (mqttClient.connected() || mqttStatus == ConnState::Connecting) {
         return;  // Avoid parallel connection attempts
     }
-    if (mqttReconnectTimer) {
-        xTimerStop(mqttReconnectTimer, 0);
-    }
     if (WiFi.status() != WL_CONNECTED) {
-        Serial.println("WiFi not connected, delaying MQTT connection");
-        if (mqttReconnectTimer) {
-            xTimerStart(mqttReconnectTimer, pdMS_TO_TICKS(5000));
-        }
+        Serial.println("WiFi not connected, skipping MQTT connection");
         return;
     }
     if (mqtt_server.empty()) {
         Serial.println("MQTT server not configured");
         return;
     }
+    s_lastMqttConnectAttemptMs = millis();
     Serial.printf("Connecting to MQTT at %s:%u...\n", mqtt_server.c_str(), mqtt_port);
     addLogMessage(String("Connecting to MQTT at ") + mqtt_server.c_str() + ":" + String(mqtt_port));
     mqttStatus = ConnState::Connecting;
@@ -317,8 +330,27 @@ void onMqttDisconnect(AsyncMqttClientDisconnectReason reason) {
     addLogMessage(String("Disconnected from MQTT (reason ") + String(static_cast<uint8_t>(reason)) + ")");
     mqttStatus = ConnState::Disconnected;
     updateDisplayStatus();
-    if (WiFi.status() == WL_CONNECTED && mqttReconnectTimer) {
-        xTimerStart(mqttReconnectTimer, 0);
+    stopHeartbeat();
+}
+
+static void mqttSchedulerTask(void*) {
+    while (true) {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+
+        const uint32_t now = millis();
+
+        if (mqttStatus == ConnState::Disconnected && WiFi.status() == WL_CONNECTED &&
+            static_cast<int32_t>(now - s_lastMqttConnectAttemptMs) >= static_cast<int32_t>(MQTT_RECONNECT_INTERVAL_MS)) {
+            connectToMqtt();
+        }
+
+        if (s_heartbeatEnabled.load() &&
+            static_cast<int32_t>(now - s_nextHeartbeatAtMs.load()) >= 0) {
+            s_nextHeartbeatAtMs.store(now + 60000UL);
+            if (mqttStatus == ConnState::Connected && mqttClient.connected()) {
+                publishHeartbeat();
+            }
+        }
     }
 }
 

--- a/src/oled_display.cpp
+++ b/src/oled_display.cpp
@@ -25,14 +25,16 @@
 #include <display_helpers.h>
 #include <atomic>
 #include <chrono>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RST);
 DisplayBuffer displayBuffer;
 SemaphoreHandle_t displayBufferMutex = xSemaphoreCreateMutex();
-TimerHandle_t displayUpdateTimer;
+TaskHandle_t displayTaskHandle = nullptr;
 std::chrono::time_point<std::chrono::system_clock> startTime;
 std::atomic<int64_t> lastDataTime = 0;
-void handleTimerTick(TimerHandle_t);
+void displayTask(void *);
 
 const int MILLIS_BETWEEN_DISPLAY_UPDATE_SLOW = 5000;
 const int MILLIS_BETWEEN_DISPLAY_UPDATE_FAST = 100;
@@ -130,11 +132,17 @@ int mqttStatusToIconIndex() {
 const bool fast = true;
 const bool slow = false;
 std::atomic<bool> timerIsFast = false;
+
+static void notifyDisplayTask() {
+    if (displayTaskHandle != nullptr) {
+        xTaskNotifyGive(displayTaskHandle);
+    }
+}
+
 void setTimerSpeed(bool needsFast) {
     if (needsFast != timerIsFast) {
-        xTimerChangePeriod(displayUpdateTimer, pdMS_TO_TICKS(needsFast ? MILLIS_BETWEEN_DISPLAY_UPDATE_FAST : MILLIS_BETWEEN_DISPLAY_UPDATE_SLOW), 0);
-
         timerIsFast = needsFast;
+        notifyDisplayTask();
     }
 }
 
@@ -144,20 +152,15 @@ bool initDisplay() {
         return false;
     }
 
+    if (xTaskCreatePinnedToCore(displayTask, "DisplayTask", 4096, nullptr, 1,
+                                &displayTaskHandle, tskNO_AFFINITY) != pdPASS) {
+        Serial.println("Failed to create display task");
+        return false;
+    }
+
     startTime = std::chrono::system_clock::now();
     lastDataTime = esp_timer_get_time();
-    displayUpdateTimer = xTimerCreate(
-        "displayTimer",
-        pdMS_TO_TICKS(MILLIS_BETWEEN_DISPLAY_UPDATE_FAST),
-        pdTRUE,
-        nullptr,
-        handleTimerTick
-    );
-    if (displayUpdateTimer) {
-        xTimerStart(displayUpdateTimer, 0);
-    } else {
-        Serial.println("Failed to create display update timer");
-    }
+    xTaskNotifyGive(displayTaskHandle);
 
     return true;
 }
@@ -197,6 +200,7 @@ void displayCustomMessage(const char* message, const char* status) {
     xSemaphoreGive(displayBufferMutex);
 
     setTimerSpeed(fast);
+    notifyDisplayTask();
 }
 
 void clearDisplayMessages() {
@@ -211,6 +215,7 @@ void clearDisplayMessages() {
 
 void updateDisplayStatus() {
     setTimerSpeed(fast);
+    notifyDisplayTask();
 }
 
 void drawLogo(int x, int y) {
@@ -281,18 +286,24 @@ void drawLogo() {
     drawLogo(x, y);
 }
 
-void handleTimerTick(TimerHandle_t) {
-    display.clearDisplay();
+void displayTask(void *) {
+    while (true) {
+        const TickType_t waitTicks = pdMS_TO_TICKS(timerIsFast ? MILLIS_BETWEEN_DISPLAY_UPDATE_FAST
+                                                               : MILLIS_BETWEEN_DISPLAY_UPDATE_SLOW);
+        ulTaskNotifyTake(pdTRUE, waitTicks);
 
-    const auto secondsSinceNoData = getSecondsSinceNoData();
+        display.clearDisplay();
 
-    if (timerIsFast || secondsSinceNoData < SECONDS_BEFORE_SCREENSAVER) {
-        drawData();
-    } else {
-        drawLogo();
+        const auto secondsSinceNoData = getSecondsSinceNoData();
+
+        if (timerIsFast || secondsSinceNoData < SECONDS_BEFORE_SCREENSAVER) {
+            drawData();
+        } else {
+            drawLogo();
+        }
+
+        display.display();
     }
-
-    display.display();
 }
 
 #endif

--- a/src/oled_display.cpp
+++ b/src/oled_display.cpp
@@ -23,13 +23,15 @@
 #include <wifi_helper.h>
 #include <WiFi.h>
 #include <display_helpers.h>
+#include <atomic>
 #include <chrono>
 
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RST);
 DisplayBuffer displayBuffer;
+SemaphoreHandle_t displayBufferMutex = xSemaphoreCreateMutex();
 TimerHandle_t displayUpdateTimer;
 std::chrono::time_point<std::chrono::system_clock> startTime;
-std::chrono::time_point<std::chrono::system_clock> timeSinceNoData;
+std::atomic<int64_t> lastDataTime = 0;
 void handleTimerTick(TimerHandle_t);
 
 const int MILLIS_BETWEEN_DISPLAY_UPDATE_SLOW = 5000;
@@ -127,7 +129,7 @@ int mqttStatusToIconIndex() {
 
 const bool fast = true;
 const bool slow = false;
-bool timerIsFast = false;
+std::atomic<bool> timerIsFast = false;
 void setTimerSpeed(bool needsFast) {
     if (needsFast != timerIsFast) {
         xTimerChangePeriod(displayUpdateTimer, pdMS_TO_TICKS(needsFast ? MILLIS_BETWEEN_DISPLAY_UPDATE_FAST : MILLIS_BETWEEN_DISPLAY_UPDATE_SLOW), 0);
@@ -143,7 +145,7 @@ bool initDisplay() {
     }
 
     startTime = std::chrono::system_clock::now();
-    timeSinceNoData = startTime;
+    lastDataTime = esp_timer_get_time();
     displayUpdateTimer = xTimerCreate(
         "displayTimer",
         pdMS_TO_TICKS(MILLIS_BETWEEN_DISPLAY_UPDATE_FAST),
@@ -169,15 +171,7 @@ int getSecondsSinceStart() {
 }
 
 int getSecondsSinceNoData() {
-    return getSecondsSince(timeSinceNoData);
-}
-
-template<typename ... Args>
-std::string format(const std::string &format, Args ... args)
-{
-    char buf[250];
-    snprintf(buf, 250, format.c_str(), args ...);
-    return std::string(buf);
+    return (esp_timer_get_time() - lastDataTime.load()) / 1000000LL;;
 }
 
 const char* getRemoteName(const uint8_t *remote, const char *name) {
@@ -190,16 +184,30 @@ const char* getRemoteName(const uint8_t *remote, const char *name) {
 }
 
 void display1WAction(const uint8_t *remote, const char *action, const char *dir, const char *name) {
-    displayBuffer.addLine(format("%s: %s", dir, getRemoteName(remote, name)), action);
-
-    setTimerSpeed(fast);
+    displayCustomMessage(format("%s: %s", dir, getRemoteName(remote, name)).c_str(), action);
 }
 
 void display1WPosition(const uint8_t *remote, float position, const char *name) {
-    displayBuffer.addLine(getRemoteName(remote, name), format("%d%%", static_cast<int>(position)));
+    displayCustomMessage(getRemoteName(remote, name), format("%d%%", static_cast<int>(position)).c_str());
+}
+
+void displayCustomMessage(const char* message, const char* status) {
+    xSemaphoreTake(displayBufferMutex, portMAX_DELAY);
+    displayBuffer.addLine(message, status ? status : "");
+    xSemaphoreGive(displayBufferMutex);
 
     setTimerSpeed(fast);
 }
+
+void clearDisplayMessages() {
+    xSemaphoreTake(displayBufferMutex, portMAX_DELAY);
+    displayBuffer.clear();
+    xSemaphoreGive(displayBufferMutex);
+
+    lastDataTime.store(esp_timer_get_time());
+    setTimerSpeed(slow);
+}
+
 
 void updateDisplayStatus() {
     setTimerSpeed(fast);
@@ -222,7 +230,7 @@ void drawHeader() {
 #endif // MQTT
 
     // wifi icon is 8x7
-    const auto wifiIcon = wifiIcons[min(wifiStatus.signalStrengthPercent, 99) / 25];
+    const auto wifiIcon = wifiIcons[min(wifiStatus.signalStrengthPercent.load(), 99) / 25];
     display.drawBitmap(127-8, 3, wifiIcon, 8, 7, SSD1306_WHITE);
 }
 
@@ -242,37 +250,46 @@ bool drawContents() {
     const int width = SCREEN_WIDTH / 6; // char width is 5 + 1 pixel space
     const int height = (SCREEN_HEIGHT - 20 - 8) / 8; // char height is 7 + 1 pixel space and 20 pixels (12 pixels + an empty line) for the header + 8 for the footer
 
+    xSemaphoreTake(displayBufferMutex, portMAX_DELAY);
     const auto lines = displayBuffer.getTextToDisplay(width, height);
+    xSemaphoreGive(displayBufferMutex);
     for(auto &line : lines) {
         display.println(line.c_str());
     }
     return lines.size() > 0;
 }
 
+void drawData() {
+    display.setTextSize(1);
+    display.setTextColor(SSD1306_WHITE);
+
+    drawHeader();
+
+    display.setCursor(0, 20);
+    const bool hasData = drawContents();
+    if (!hasData) {
+        setTimerSpeed(slow);
+    }
+
+    drawFooter();
+}
+
+void drawLogo() {
+    // draw logo at random position to avoid burn-in
+    const int x = 50.0 * std::rand() / RAND_MAX; // number between 0 and 50
+    const int y = 48.0 * std::rand() / RAND_MAX; // number between 0 and 48
+    drawLogo(x, y);
+}
+
 void handleTimerTick(TimerHandle_t) {
     display.clearDisplay();
 
-    timeSinceNoData = timerIsFast ? std::chrono::system_clock::now() : timeSinceNoData;
     const auto secondsSinceNoData = getSecondsSinceNoData();
 
     if (timerIsFast || secondsSinceNoData < SECONDS_BEFORE_SCREENSAVER) {
-        display.setTextSize(1);
-        display.setTextColor(SSD1306_WHITE);
-
-        drawHeader();
-
-        display.setCursor(0, 20);
-        const bool hasData = drawContents();
-        if (!hasData) {
-            setTimerSpeed(slow);
-        }
-
-        drawFooter();
+        drawData();
     } else {
-        // draw logo at random position to avoid burn-in
-        const int x = 50.0 * std::rand() / RAND_MAX; // number between 0 and 50
-        const int y = 48.0 * std::rand() / RAND_MAX; // number between 0 and 48
-        drawLogo(x, y);
+        drawLogo();
     }
 
     display.display();

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -285,3 +285,8 @@ void initWifi() {
 
     Serial.printf("WiFi MAC: %s\n", WiFi.macAddress().c_str());
 }
+
+void clearWifi() {
+    WiFi.eraseAP();
+    esp_restart();
+}

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -72,8 +72,7 @@ static void ensureWebServerStarted() {
 static void onMqttAfterWifi() {
 #if defined(MQTT)
         // Establish MQTT connection if needed and MQTT client is initialized
-        if (mqttReconnectTimer && !mqttClient.connected() &&
-            mqttStatus != ConnState::Connecting) {
+        if (!mqttClient.connected() && mqttStatus != ConnState::Connecting) {
             connectToMqtt();
         }
 #endif

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -22,70 +22,54 @@
 #endif
 #include <WiFiManager.h>
 #include <ESPmDNS.h>
+#include <TickerUsESP32.h>
+#include <tuple>
 
-TimerHandle_t wifiReconnectTimer;
+const long PORTAL_TIMEOUT = 300000; // 5 minuten = 300.000 ms
+const uint32_t WIFI_NOTIFY_GOT_IP = BIT0;
+const uint32_t WIFI_NOTIFY_DISCONNECTED = BIT1;
+const uint32_t WIFI_NOTIFY_RECONNECT = BIT2;
 
+// below variables are thread safe because of the use of a single task that reads/modifies them (except for wifiStatus, but that one has atomic fields)
+TimersUS::TickerUsESP32 wifiReconnectTimer {};
+TimersUS::TickerUsESP32 rssiTimer {};
 WiFiStatus wifiStatus = { ConnState::Disconnected, 0 };
 
-void initWifi() {
-    wifiReconnectTimer = xTimerCreate(
-        "wifiTimer",
-        pdMS_TO_TICKS(10000),  // 10 seconds retry interval
-        pdFALSE,
-        nullptr,
-        connectToWifi
-    );
-    if (!wifiReconnectTimer) {
-        Serial.println("Failed to create WiFi reconnect timer");
-    }
-    connectToWifi(nullptr);
+TaskHandle_t wifiWorkerTaskHandle = NULL;
+bool mdnsStarted = false;
+bool webServerStarted = false;
+
+// Replicate WiFiManager::getRSSIasQuality() without constructing a WiFiManager object.
+static int rssiToQuality(int rssi) {
+    if (rssi <= -100) return 0;
+    if (rssi >= -50)  return 100;
+    return 2 * (rssi + 100);
 }
 
-void connectToWifi(TimerHandle_t /*timer*/) {
-    Serial.println("Connecting to Wi-Fi...");
-    wifiStatus = { ConnState::Connecting, 0 };
-
-    updateDisplayStatus();
-
-    WiFi.mode(WIFI_STA);
-    WiFi.setHostname("MIOPENIO");
-
-    unsigned long startTime = millis();
-    WiFi.begin();
-    wl_status_t result = static_cast<wl_status_t>(WiFi.waitForConnectResult(5000UL)); // ms
-
-    WiFiManager wm;
-    wm.setConnectTimeout(30);        // 10 sec voor verbinding met AP
-    wm.setConfigPortalTimeout(180);  // 3 min captive portal open
-
-    bool res = false;
-    if (result == WL_CONNECTED) {
-        res = true;
-    } else {
-        Serial.println("Stored WiFi credentials failed, launching WiFiManager portal");
-        res = wm.autoConnect("iohc-setup");
+static void notifyWiFiWorker(uint32_t bits) {
+    if (wifiWorkerTaskHandle != NULL) {
+        xTaskNotify(wifiWorkerTaskHandle, bits, eSetBits);
     }
+}
 
-    unsigned long duration = millis() - startTime;
+static void rssiTimerCb() {
+    if (WiFi.status() == WL_CONNECTED) {
+        wifiStatus.signalStrengthPercent = rssiToQuality(WiFi.RSSI());
+    }
+}
 
-    if (!res) {
-        Serial.printf("WiFi connection failed after %lu ms\n", duration);
-        wifiStatus = { ConnState::Disconnected, 0 };
+static void wifiReconnectTimerCb() {
+    notifyWiFiWorker(WIFI_NOTIFY_RECONNECT);
+}
 
-        // Retry later
-        if (wifiReconnectTimer) {
-            xTimerStart(wifiReconnectTimer, 0);
-        }
-    } else {
-        Serial.printf("Connected to WiFi in %lu ms. IP address: %s\n", duration,
-                      WiFi.localIP().toString().c_str());
-        wifiStatus = { ConnState::Connected, wm.getRSSIasQuality(WiFi.RSSI()) };
+static void ensureWebServerStarted() {
+    if (!webServerStarted) {
+        setupWebServer();
+        webServerStarted = true;
+    }
+}
 
-        if (!MDNS.begin("miopenio")) {
-            Serial.println("Error setting up MDNS responder!");
-        } else {
-            Serial.println("MDNS responder started at http://miopenio.local");
-        }
+static void onMqttAfterWifi() {
 #if defined(MQTT)
         // Establish MQTT connection if needed and MQTT client is initialized
         if (mqttReconnectTimer && !mqttClient.connected() &&
@@ -93,25 +77,211 @@ void connectToWifi(TimerHandle_t /*timer*/) {
             connectToMqtt();
         }
 #endif
+}
+
+static void handleWifiConnected() {
+    if (WiFi.status() == WL_CONNECTED) {
+        wifiStatus.connectionStatus = ConnState::Connected;
+        wifiStatus.signalStrengthPercent = rssiToQuality(WiFi.RSSI());
+
+        wifiReconnectTimer.detach();
+        rssiTimer.attach(5, rssiTimerCb);
+        updateDisplayStatus();
+
+        if (!mdnsStarted) {
+            if (!MDNS.begin("miopenio")) {
+                Serial.println("WiFi: mDNS start failed");
+            } else {
+                mdnsStarted = true;
+                Serial.println("WiFi: mDNS started at http://miopenio.local");
+            }
+        }
+
+        ensureWebServerStarted();
+        onMqttAfterWifi();
     }
 }
 
-void checkWifiConnection() {
-    if (WiFi.status() != WL_CONNECTED) {
-        if (wifiStatus.connectionStatus == ConnState::Connected) {
-            Serial.println("WiFi connection lost");
-            wifiStatus = { ConnState::Disconnected, 0 };
-            updateDisplayStatus();
+static void configureWifiDisconnected() {
+    Serial.println("WiFi: connection lost (event)");
+    wifiStatus.connectionStatus = ConnState::Disconnected;
+    wifiStatus.signalStrengthPercent = 0;
+    rssiTimer.detach();
+    wifiReconnectTimer.attach(10, wifiReconnectTimerCb);
+    mdnsStarted = false;
+    updateDisplayStatus();
+}
 
-#if defined(MQTT)
-            Serial.println("Stopping MQTT reconnect timer");
-            if (mqttReconnectTimer) {
-                xTimerStop(mqttReconnectTimer, 0);
+static void handleWifiDisconnected() {
+    if (wifiStatus.connectionStatus == ConnState::Connected) {
+        configureWifiDisconnected();
+    }
+}
+
+static void applyAdvancedWiFiSettings() {
+    wifi_config_t config;
+    if (esp_wifi_get_config(WIFI_IF_STA, &config) == ESP_OK) {
+        config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;   
+#ifdef REQUIRE_MINIMUM_WPA2_PSK  
+        // This is necessary to prevent the device from Evil Twin attacks, where an attacker creates an additional network with the same
+        // SSID as the one selected. WPA2_PSK will detect that and even prevent sending the password. 
+
+        // Enable minimal WPA2_PSK level (also allows WPA3 or other more secure modes)
+        config.sta.threshold.authmode = WIFI_AUTH_WPA_PSK; 
+#endif // REQUIRE_MINIMUM_WPA2_PSK
+        esp_wifi_set_config(WIFI_IF_STA, &config);
+    }
+}
+
+static std::string getConfiguredSSID() {
+    wifi_config_t conf {};
+    if (esp_wifi_get_config(WIFI_IF_STA, &conf) != ESP_OK) {
+        return {};
+    }
+
+    return std::string(reinterpret_cast<const char*>(conf.sta.ssid));
+}
+
+static void triggerWiFiReconnect() {
+    if (WiFi.status() != WL_CONNECTED) {
+        Serial.println("WiFi: Trigger WiFi reconnect...");
+        applyAdvancedWiFiSettings(); 
+        WiFi.mode(WIFI_STA); 
+        WiFi.begin();
+    }
+}
+
+static std::tuple<int, int> millisToMinutesAndSeconds(long millis) {
+    auto secondsRemaining = millis / 1000;
+    return { secondsRemaining / 60, secondsRemaining % 60 };
+}
+
+static void runConfigPortal(const std::string& ssid, bool hasWifiConfiguration) {
+    if (hasWifiConfiguration) {
+        Serial.println("WiFi: Configured network not found, opening Config Portal...");
+    } else {
+        Serial.println("WiFi: No WiFi network configured, opening Config Portal...");
+    }
+
+    WiFiManager wm;
+
+    applyAdvancedWiFiSettings();
+    wm.setConfigPortalBlocking(false);
+    wm.setDisableConfigPortal(true); // allow config portal shutdown when previous configured wifi comes available.
+    wm.setConfigPortalTimeout(PORTAL_TIMEOUT / 1000);
+    wm.autoConnect("iohc-setup");
+
+    const unsigned long portalStartTime = millis();
+    bool portalClosed = false;
+    while (!portalClosed) {
+        // Keep telling this info to keep it visible on the display
+        if (hasWifiConfiguration) {
+            displayCustomMessage("WiFi not found.", ssid.c_str());
+        } else {
+            displayCustomMessage("WiFi not configured.");
+        }
+        displayCustomMessage("Custom WiFi AP", "iohc-setup");
+
+        const long millisRemaining = PORTAL_TIMEOUT - static_cast<long>(millis() - portalStartTime);
+        auto remainingTime = millisToMinutesAndSeconds(millisRemaining);
+        displayCustomMessage("Remaining time", format("%2dm %02ds", std::get<0>(remainingTime), std::get<1>(remainingTime)).c_str());
+
+        const bool connected = wm.process(); // Required for async config portal handling
+
+        vTaskDelay(pdMS_TO_TICKS(100));
+
+        if (connected || WiFi.status() == WL_CONNECTED) {
+            portalClosed = true;
+
+            if (connected) {
+                // workaround for bug in WiFiManager that causes the config portal webserver not to be shut down correctly (keeps port in use)
+                esp_restart();
             }
-#endif
-            if (wifiReconnectTimer) {
-                xTimerStart(wifiReconnectTimer, 0);
+        } else if (millisRemaining < 0) {
+            Serial.println("WiFi: Config portal timeout, closing portal...");
+            portalClosed = true;
+
+            if (hasWifiConfiguration) {
+                Serial.printf("WiFi: Device keeps waiting for connection on network: %s. Restart to re-open config portal.\n", ssid.c_str());
+            } else {
+                Serial.println("WiFi: Restart the device manually to re-open the config portal!");
             }
         }
     }
+
+    clearDisplayMessages();
+}
+
+static void wifiWorker(void * pvParameters) {
+    wl_status_t status = WL_DISCONNECTED;
+
+    WiFi.mode(WIFI_STA);
+
+    const std::string ssid = getConfiguredSSID();
+    const bool hasWifiConfiguration = !ssid.empty();
+    if (hasWifiConfiguration) {
+        applyAdvancedWiFiSettings();
+        WiFi.begin();
+
+        Serial.printf("WiFi: Attempt connection to '%s', try for max 30 seconds...\n", ssid.c_str());
+        status = (wl_status_t)WiFi.waitForConnectResult(30000);
+    }
+    if (status != WL_CONNECTED) {
+        runConfigPortal(ssid, hasWifiConfiguration);
+    }
+
+    if (WiFi.status() != WL_CONNECTED) {
+        configureWifiDisconnected();
+    }
+
+    uint32_t events = 0;
+    while (true) {
+        xTaskNotifyWait(0, UINT32_MAX, &events, portMAX_DELAY);
+
+        if ((events & WIFI_NOTIFY_DISCONNECTED) != 0) {
+            handleWifiDisconnected();
+        }
+
+        if ((events & WIFI_NOTIFY_RECONNECT) != 0) {
+            triggerWiFiReconnect();
+        }
+
+        if ((events & WIFI_NOTIFY_GOT_IP) != 0 &&
+            wifiStatus.connectionStatus != ConnState::Connected) {
+            handleWifiConnected();
+        }
+    }
+}
+
+static void onWiFiEvent(WiFiEvent_t event) {
+    switch (event) {
+        case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+            notifyWiFiWorker(WIFI_NOTIFY_GOT_IP);
+            break;
+
+        case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
+            notifyWiFiWorker(WIFI_NOTIFY_DISCONNECTED);
+            break;
+            
+        default:
+            break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void initWifi() {
+    // Set hostname before the WiFi stack initialises so the DHCP client
+    // advertises the correct name from the very first connection attempt,
+    // including after auto-reconnects where the connect task never runs.
+    WiFi.setHostname("MiOpenIO");
+
+    xTaskCreatePinnedToCore(wifiWorker, "WiFi_Worker", 8192, NULL, 3, &wifiWorkerTaskHandle, 1);
+
+    WiFi.onEvent(onWiFiEvent);
+    WiFi.setAutoReconnect(true);
+
+    Serial.printf("WiFi MAC: %s\n", WiFi.macAddress().c_str());
 }


### PR DESCRIPTION
I noticed that there were some thread safety issues in the display code and in the WiFi code (together with some other stability issues) and mqtt code (based on crashes I observed during testing). Now it should be more stable.

So I came up with these changes in order to make them more thorough. The display code has only slight improvements which should avoid crashes and make this safer. The WiFi code has been rewritten, such that we can avoid mutexes/semaphores for simplicity and that the WiFi itself becomes more stable. One issue I found earlier was for example that when a WiFi network was temporary unavailable, the device did not properly reconnect, making it unreachable.

One reason to use tasks in favor of timers is that with timers you have to rely on what the OS gives you wrt stack size etc. With tasks you are more in control (and also have more control over threading).

In this case the config portal only opens when upon start there is no network configured or the configured network is not available. It closes after 5 minutes (PORTAL_TIMEOUT constant). It won't reopen until you restart the device. When the configured network becomes available again while the config portal is open, you also need to restart the device. This is necessary as the WiFiManager does not allow scanning for configured networks while config portal is open. While the config portal is open, the display shows instructions.

Tested scenarios:
* Device connects to configured WiFi upon start (the basic scenario)
* Device reconnects when the connection was dropped
* Config Portal opens when no network is configured
* Config Portal closes when network is configured and restarts the device to ensure everything is in order for correct functioning.
* Config Portal closes after 5 minutes when no network was selected, in case of already configured network becomes available, it will reconnect automatically. In case there was no configured network, you need to manually restart the device to trigger the portal again.