### PR TITLE
Packet improvements

### DIFF
--- a/include/iohcCozyDevice2W.h
+++ b/include/iohcCozyDevice2W.h
@@ -84,7 +84,6 @@ namespace IOHC {
         };
 
         std::vector<device> devices;
-        std::vector<iohcPacket *> packets2send{};
     };
 }
 #endif

--- a/include/iohcDevice.h
+++ b/include/iohcDevice.h
@@ -66,7 +66,6 @@ namespace IOHC {
         bool Fake = false;
         bool Home = false;
 
-        std::vector<iohcPacket *> packets2send{};
         iohcRadio *_radioInstance{};
     };
 }

--- a/include/iohcOtherDevice2W.h
+++ b/include/iohcOtherDevice2W.h
@@ -84,9 +84,6 @@ namespace IOHC {
         //            std::vector<uint16_t> _type;
         //            uint8_t _manufacturer;
 
-        //            IOHC::iohcPacket *packets2send[2]; //[25];
-        // std::array<iohcPacket*, 25> packets2send{};
-        std::vector<iohcPacket *> packets2send{};
         //            IOHC::iohcRadio *_radioInstance;
     };
 }

--- a/include/iohcRadio.h
+++ b/include/iohcRadio.h
@@ -65,6 +65,7 @@ namespace IOHC {
                 ERROR        ///< Error or unknown state
             };
             void start(uint8_t num_freqs, uint32_t *scan_freqs, uint32_t scanTimeUs, IohcPacketDelegate rxCallback, IohcPacketDelegate txCallback);
+            void send(iohcPacket *packet);
             void send(std::vector<iohcPacket*>&iohcTx);
             void sendAuto(std::vector<iohcPacket*>&iohcTx); // Nieuwe versie voor AutoTxRx
             static void setRadioState(RadioState newState);

--- a/include/iohcRemote1W.h
+++ b/include/iohcRemote1W.h
@@ -95,9 +95,6 @@ namespace IOHC {
 
 
         std::vector<remote> remotes;
-
-        std::vector<iohcPacket *> packets2send{};
-
     };
 }
 #endif

--- a/src/iohcCozyDevice2W.cpp
+++ b/src/iohcCozyDevice2W.cpp
@@ -84,7 +84,6 @@ namespace IOHC {
             case DeviceButton::associate: {
                 std::vector<uint8_t> toSend = {};
 
-                packets2send.clear();
                 auto* packet = new iohcPacket;
                 forgePacket(packet, toSend);
 
@@ -98,15 +97,13 @@ namespace IOHC {
                 memcpy(packet->payload.packet.header.source, gateway, 3);
                 memcpy(packet->payload.packet.header.target, master_to, 3);
 
-                packets2send.push_back(packet);
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 break;
             }
             case DeviceButton::powerOn: {
                 std::vector<uint8_t> toSend = {0x0C, 0x60, 0x01, 0x2C};
 
-                packets2send.clear();
                 auto* packet = new iohcPacket;
                 forgePacket(packet, toSend);
 
@@ -119,9 +116,8 @@ namespace IOHC {
                 memcpy(packet->payload.packet.header.source, gateway, 3);
                 memcpy(packet->payload.packet.header.target, master_to, 3);
 
-                packets2send.push_back(packet);
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
 
                 break;
             }
@@ -135,7 +131,6 @@ namespace IOHC {
                 if (data->size() == 2) addr = 0;
                 else addr = std::stoi(data->at(2));
 
-                packets2send.clear();
                 auto* packet = new iohcPacket;
                 forgePacket(packet, toSend);
 
@@ -150,9 +145,8 @@ namespace IOHC {
 
                 packet->delayed = 50;
 
-                packets2send.push_back(packet);
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 //                mqttClient.publish("iown/Frame", 0, false, message.c_str(), messageSize);
 
                 break;
@@ -173,18 +167,19 @@ namespace IOHC {
 
                 size_t dest = 0;
 
-                packets2send.clear();
+                std::vector<iohcPacket *> packets2send;
                 for (const auto &addr: addresses) {
-                    packets2send.push_back(new iohcPacket);
-                    forgePacket(packets2send.back(), toSend);
+                    auto* packet = new iohcPacket;
+                    packets2send.push_back(packet);
+                    forgePacket(packet, toSend);
 
-                    packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
+                    packet->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
                     memorizeSend.memorizedData = toSend;
                     memorizeSend.memorizedCmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
 
-                    packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
-                    memcpy(packets2send.back()->payload.packet.header.source, gateway, 3);
-                    memcpy(packets2send.back()->payload.packet.header.target,
+                    packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                    memcpy(packet->payload.packet.header.source, gateway, 3);
+                    memcpy(packet->payload.packet.header.target,
                            addresses.at(dest/*addr*/).data()/* 0 Master_to*/, 3);
 
                     dest++;
@@ -203,21 +198,20 @@ namespace IOHC {
                 if (strcasecmp(dat, "on") == 0) toSend[4] = 0x01;
                 if (strcasecmp(dat, "off") == 0) toSend[4] = 0x00;
 
-                packets2send.clear();
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend);
+                auto* packet = new iohcPacket;
+                forgePacket(packet, toSend);
 
-                packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
+                packet->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
                 memorizeSend.memorizedData = toSend;
                 memorizeSend.memorizedCmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                memcpy(packets2send.back()->payload.packet.header.source, gateway, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, master_to, 3);
+                memcpy(packet->payload.packet.header.source, gateway, 3);
+                memcpy(packet->payload.packet.header.target, master_to, 3);
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 break;
             }
             case DeviceButton::setWindow: {
@@ -231,23 +225,22 @@ namespace IOHC {
                 if (data->size() == 2) addr = 0;
                 else addr = std::stoi(data->at(2));
 
-                packets2send.clear();
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend);
+                auto* packet = new iohcPacket;
+                forgePacket(packet, toSend);
 
-                packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
+                packet->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
                 memorizeSend.memorizedData = toSend;
                 memorizeSend.memorizedCmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                memcpy(packets2send.back()->payload.packet.header.source, gateway, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, addresses.at(addr).data()/* 0 Master_to*/, 3);
+                memcpy(packet->payload.packet.header.source, gateway, 3);
+                memcpy(packet->payload.packet.header.target, addresses.at(addr).data()/* 0 Master_to*/, 3);
 
-                packets2send.back()->delayed = 50;
+                packet->delayed = 50;
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 break;
             }
             case DeviceButton::midnight: {
@@ -255,21 +248,20 @@ namespace IOHC {
                 std::vector<uint8_t> toSend = {0x0c, 0x60, 0x01, 0x30};
                 //, 0x2b, 0x05, 0x00, 0x0f, 0x04, 0x0c, 0xe7, 0x07};
 
-                packets2send.clear();
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend);
+                auto *packet = new iohcPacket;
+                forgePacket(packet, toSend);
 
-                packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
+                packet->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
                 memorizeSend.memorizedData = toSend;
                 memorizeSend.memorizedCmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                memcpy(packets2send.back()->payload.packet.header.source, gateway, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, master_to, 3);
+                memcpy(packet->payload.packet.header.source, gateway, 3);
+                memcpy(packet->payload.packet.header.target, master_to, 3);
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
 
                 break;
             }

--- a/src/iohcOtherDevice2W.cpp
+++ b/src/iohcOtherDevice2W.cpp
@@ -75,23 +75,24 @@ namespace IOHC {
             Serial.println("NO RADIO INSTANCE");
             _radioInstance = iohcRadio::getInstance();
         }
-        packets2send.clear();
 
         // Emulates device button press
         switch (cmd) {
             case Other2WButton::discovery: {
                 int bec = 0;
 
+                std::vector<iohcPacket *> packets2send;
                 for (int j = 0; j < 255; j++) {
-                    packets2send.push_back(new iohcPacket);
+                    auto *packet = new iohcPacket;
+                    packets2send.push_back(packet);
 
                     std::string discovery = "d430477706ba11ad31"; //28"; //"2b578ebc37334d6e2f50a4dfa9";
                     std::vector<uint8_t> toSend = {};
-                    packets2send.back()->buffer_length = hexStringToBytes(
-                        discovery, packets2send.back()/*[j]*/->payload.buffer);
-                    forgePacket(packets2send.back()/*[j]*//*->payload.buffer[4]*/, toSend, bec);
+                    packet->buffer_length = hexStringToBytes(
+                        discovery, packet/*[j]*/->payload.buffer);
+                    forgePacket(packet/*[j]*//*->payload.buffer[4]*/, toSend, bec);
                     bec += 0x01;
-                    packets2send.back()->repeatTime = 250; // Slow down discovery loop
+                    packet->repeatTime = 250; // Slow down discovery loop
                 }
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
@@ -112,30 +113,31 @@ namespace IOHC {
                 // uint8_t target[3] = {0x08, 0x42, 0xE3};
                 // toSend[3] = custom;
 
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend, 0);
-                packets2send.back()->payload.packet.header.cmd = SEND_GET_NAME_0x50;
+                auto *packet = new iohcPacket;
+                forgePacket(packet, toSend, 0);
+                packet->payload.packet.header.cmd = SEND_GET_NAME_0x50;
                 // memorizeSend.memorizedData = toSend;
                 // memorizeSend.memorizedCmd = SEND_WRITE_PRIVATE_0x20;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
-//                packets2send.back()->payload.packet.header.CtrlByte1.asByte += toSend.size();
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+//                packet->payload.packet.header.CtrlByte1.asByte += toSend.size();
 
-                memcpy(packets2send.back()->payload.packet.header.source, fake_gateway, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, target, 3);
+                memcpy(packet->payload.packet.header.source, fake_gateway, 3);
+                memcpy(packet->payload.packet.header.target, target, 3);
 
-//                memcpy(packets2send.back()->payload.buffer + 9, toSend.data(), toSend.size());
-//                packets2send.back()->buffer_length = toSend.size() + 9;
+//                memcpy(packet->payload.buffer + 9, toSend.data(), toSend.size());
+//                packet->buffer_length = toSend.size() + 9;
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                // packets2send.back()->delayed = 501;
-                _radioInstance->send(packets2send);
+                // packet->delayed = 501;
+                _radioInstance->send(packet);
                 break;
             }
             case Other2WButton::custom: {
                 std::vector<uint8_t> toSend = {0x01, 0x47, 0xc8, 0x00, 0x00, 0x00};
                 //{0x03, 0x65, 0xd4, 0x00, 0x00, 0x00}; //{0x0C, 0x60, 0x01, 0xFF, 0xFF};
                 //const char* dat = data->at(1).c_str();
+                std::vector<iohcPacket *> packets2send;
                 for (int acei = 0; acei < 256; acei++) {
                     //               int custom = std::stoi(data->at(1));
                     AceiUnion ACEI{};
@@ -150,23 +152,23 @@ namespace IOHC {
                     address to = {0xda, 0x2e, 0xe6}; //
                     address to_1 = {0x05, 0x4e, 0x17}; //{0x31, 0x58, 0x24}; //
 
-//                    packets2send.clear();
-                    packets2send.push_back(new iohcPacket);
-                    forgePacket(packets2send.back(), toSend);
+                    auto *packet = new iohcPacket;
+                    packets2send.push_back(packet);
+                    forgePacket(packet, toSend);
 
-                    packets2send.back()->payload.packet.header.cmd = 0x00; //SEND_WRITE_PRIVATE_0x20;
+                    packet->payload.packet.header.cmd = 0x00; //SEND_WRITE_PRIVATE_0x20;
                     memorizeOther2W.memorizedData = toSend;
                     memorizeOther2W.memorizedCmd = 0x00; //SEND_WRITE_PRIVATE_0x20;
 
-                    packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
 
-                    memcpy(packets2send.back()->payload.packet.header.source, from/*gateway*/, 3);
-                    memcpy(packets2send.back()->payload.packet.header.target, to_1, 3);
+                    memcpy(packet->payload.packet.header.source, from/*gateway*/, 3);
+                    memcpy(packet->payload.packet.header.target, to_1, 3);
 
-                    packets2send.back()->delayed = 250; // Give enough time for the answer
+                    packet->delayed = 250; // Give enough time for the answer
                 }
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
                 _radioInstance->send(packets2send);
@@ -182,25 +184,24 @@ namespace IOHC {
 
                 toSend[3] = custom; //custom;
 
-//                packets2send.clear();
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend);
+                auto *packet = new iohcPacket;
+                forgePacket(packet, toSend);
 
-                packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
+                packet->payload.packet.header.cmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
                 memorizeOther2W.memorizedData = toSend;
                 memorizeOther2W.memorizedCmd = iohcDevice::SEND_WRITE_PRIVATE_0x20;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                // packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                // packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
+                // packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                // packet->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
 
-                memcpy(packets2send.back()->payload.packet.header.source, gateway/*master_from*/, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, master_to/*slave_to*/, 3);
+                memcpy(packet->payload.packet.header.source, gateway/*master_from*/, 3);
+                memcpy(packet->payload.packet.header.target, master_to/*slave_to*/, 3);
 
-                packets2send.back()->delayed = 250;
+                packet->delayed = 250;
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 break;
             }
             case Other2WButton::discover28: {
@@ -209,26 +210,27 @@ namespace IOHC {
                 //                uint8_t broadcast[3];
                 address broadcast = {0x00, 0xFF, 0xFB}; //{0x02, 0x02, 0xFB}; //data->at(1).c_str();
                 //            hexStringToBytes(dat, broadcast);
-//                packets2send.clear();
                 size_t i = 0;
+                std::vector<iohcPacket *> packets2send;
                 for (i = 0; i < 10; i++) {
-                    packets2send.push_back(new iohcPacket);
-                    forgePacket(packets2send[i], toSend);
+                    auto *packet = new iohcPacket;
+                    packets2send.push_back(packet);
+                    forgePacket(packet, toSend);
 
-                    packets2send[i]->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_0x28;
+                    packet->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_0x28;
                     memorizeOther2W.memorizedData = toSend;
                     memorizeOther2W.memorizedCmd = iohcDevice::SEND_DISCOVER_0x28;
 
-                    packets2send[i]->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
-                    packets2send[i]->payload.packet.header.CtrlByte1.asStruct.EndFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.EndFrame = 1;
 
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
 
-                    memcpy(packets2send[i]->payload.packet.header.source, gateway, 3);
-                    memcpy(packets2send[i]->payload.packet.header.target, broadcast, 3);
+                    memcpy(packet->payload.packet.header.source, gateway, 3);
+                    memcpy(packet->payload.packet.header.target, broadcast, 3);
 
-                    packets2send[i]->delayed = 250; // Give enough time for the answer
+                    packet->delayed = 250; // Give enough time for the answer
                 }
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
                 _radioInstance->send(packets2send);
@@ -253,21 +255,22 @@ namespace IOHC {
                 address broadcast_3b = {0x00, 0x00, 0x3b};
                 address broadcast_3f = {0x00, 0x00, 0x3f};
 
-//                packets2send.clear();
+                std::vector<iohcPacket *> packets2send;
                 for (size_t i = 0; i < 2; i++) {
-                    packets2send.push_back(new iohcPacket);
+                    auto *packet = new iohcPacket;
+                    packets2send.push_back(packet);
 
                     if (i > 20) {
                         std::vector<uint8_t> toSend = {0x00};
-                        forgePacket(packets2send.back(), toSend);
-                        packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_UNKNOWN_0x2E;
-                        memcpy(packets2send.back()->payload.packet.header.target, broadcast_3f, 3);
+                        forgePacket(packet, toSend);
+                        packet->payload.packet.header.cmd = iohcDevice::SEND_UNKNOWN_0x2E;
+                        memcpy(packet->payload.packet.header.target, broadcast_3f, 3);
                     }
                     if (i <= 20) {
                         std::vector<uint8_t> toSend = {};
-                        forgePacket(packets2send.back(), toSend);
-                        packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_0x28;
-                        memcpy(packets2send.back()->payload.packet.header.target, broadcast_3b, 3);
+                        forgePacket(packet, toSend);
+                        packet->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_0x28;
+                        memcpy(packet->payload.packet.header.target, broadcast_3b, 3);
                     }
                     if (i <= 10) {
                         std::vector<uint8_t> toSend = {
@@ -276,25 +279,25 @@ namespace IOHC {
                         std::vector<uint8_t> toSend2 = {
                             0xa0, 0xb4, 0x38, 0xd2, 0x5f, 0x27, 0x28, 0x6f, 0xed, 0xd2, 0xad, 0x1f
                         };
-                        forgePacket(packets2send.back(), toSend2);
-                        packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_REMOTE_0x2A;
-                        memcpy(packets2send.back()->payload.packet.header.target, broadcast_3b, 3);
+                        forgePacket(packet, toSend2);
+                        packet->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_REMOTE_0x2A;
+                        memcpy(packet->payload.packet.header.target, broadcast_3b, 3);
                     }
-                    //                    packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_REMOTE_0x2A;
+                    //                    packet->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_REMOTE_0x2A;
 
                     //                    memorizeSend.memorizedData = toSend; //.assign(toSend, toSend + 12);
                     //                    memorizeSend.memorizedCmd = iohcDevice::SEND_DISCOVER_REMOTE_0x2A;
 
-                    packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
-                    packets2send.back()->payload.packet.header.CtrlByte1.asStruct.EndFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.EndFrame = 1;
 
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
 
-                    memcpy(packets2send.back()->payload.packet.header.source, /*from*/realcopy/*gateway*/, 3);
+                    memcpy(packet->payload.packet.header.source, /*from*/realcopy/*gateway*/, 3);
 
-                    packets2send.back()->delayed = 250; // Give enough time for the answer
-                    packets2send.back()->repeatTime = 250; // Slow down discover loop
+                    packet->delayed = 250; // Give enough time for the answer
+                    packet->repeatTime = 250; // Slow down discover loop
                 }
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 
@@ -320,27 +323,28 @@ namespace IOHC {
                     {0x47, 0x77, 0x06}, {0x48, 0x79, 0x02}, {0x8C, 0xCB, 0x30}, {0x8C, 0xCB, 0x31}
                 };
 
-//                packets2send.clear();
                 size_t i = 0;
+                std::vector<iohcPacket *> packets2send;
                 for (i = 0; i < 15; i++) {
-                    packets2send.push_back(new iohcPacket);
-                    forgePacket(packets2send.back(), toSend);
+                    auto *packet = new iohcPacket;
+                    packets2send.push_back(packet);
+                    forgePacket(packet, toSend);
 
-                    packets2send.back()->payload.packet.header.cmd = 0x00;
+                    packet->payload.packet.header.cmd = 0x00;
                     memorizeOther2W.memorizedData = toSend;
                     memorizeOther2W.memorizedCmd = 0x00;
                     IOHC::lastSendCmd = 0x00;
 
-                    packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                    packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                    packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                    // packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Unk1 = 1;
+                    packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                    // packet->payload.packet.header.CtrlByte2.asStruct.Unk1 = 1;
 
-                    memcpy(packets2send.back()->payload.packet.header.source, from/*gateway*/, 3);
-                    memcpy(packets2send.back()->payload.packet.header.target, guessed[i], 3);
+                    memcpy(packet->payload.packet.header.source, from/*gateway*/, 3);
+                    memcpy(packet->payload.packet.header.target, guessed[i], 3);
 
-                    packets2send.back()->delayed = 250; // Give enough time for the answer
-                    packets2send.back()->repeatTime = 250; // Slow down discover loop
+                    packet->delayed = 250; // Give enough time for the answer
+                    packet->repeatTime = 250; // Slow down discover loop
                 }
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
                 _radioInstance->send(packets2send);
@@ -350,21 +354,20 @@ namespace IOHC {
             case Other2WButton::ack: {
                 std::vector<uint8_t> toSend = {};
 
-//                packets2send.clear();
-                packets2send.push_back(new iohcPacket);
-                forgePacket(packets2send.back(), toSend);
+                auto *packet = new iohcPacket;
+                forgePacket(packet, toSend);
 
-                packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_KEY_TRANSFERT_ACK_0x33;
+                packet->payload.packet.header.cmd = iohcDevice::SEND_KEY_TRANSFERT_ACK_0x33;
                 memorizeOther2W.memorizedCmd = iohcDevice::SEND_KEY_TRANSFERT_ACK_0x33;
                 memorizeOther2W.memorizedData = toSend;
 
-                packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
 
-                memcpy(packets2send.back()->payload.packet.header.source, gateway, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, master_from, 3);
+                memcpy(packet->payload.packet.header.source, gateway, 3);
+                memcpy(packet->payload.packet.header.target, master_from, 3);
 
                 digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-                _radioInstance->send(packets2send);
+                _radioInstance->send(packet);
                 break;
             }
             case Other2WButton::checkCmd: {
@@ -388,7 +391,7 @@ namespace IOHC {
                 address broad = {0x00, 0x0d, 0x3b}; //{0x00, 0xFF, 0xFB}; //
 
                 uint8_t counter = 0;
-//                packets2send.clear();
+                std::vector<iohcPacket *> packets2send;
                 for (const auto &command: mapValid) {
                     if (command.second == 0 || (command.second == 5 && command.first != 0x19)) {
                         counter++;
@@ -426,26 +429,27 @@ namespace IOHC {
                         if (command.first == 0x60 || command.first == 0x82)
                             toSend.assign(special12, special12 + 21);
 
-                        packets2send.push_back(new iohcPacket);
-                        forgePacket(packets2send.back(), toSend);
-                        packets2send.back()->payload.packet.header.cmd = command.first;
-                        memorizeOther2W.memorizedCmd = packets2send.back()->payload.packet.header.cmd;
+                        auto *packet = new iohcPacket;
+                        packets2send.push_back(packet);
+                        forgePacket(packet, toSend);
+                        packet->payload.packet.header.cmd = command.first;
+                        memorizeOther2W.memorizedCmd = packet->payload.packet.header.cmd;
 
-                        packets2send.back()->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
-                        packets2send.back()->payload.packet.header.CtrlByte1.asStruct.EndFrame = 0;
-                        packets2send.back()->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
-                        packets2send.back()->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
+                        packet->payload.packet.header.CtrlByte1.asStruct.StartFrame = 1;
+                        packet->payload.packet.header.CtrlByte1.asStruct.EndFrame = 0;
+                        packet->payload.packet.header.CtrlByte2.asStruct.LPM = 1;
+                        packet->payload.packet.header.CtrlByte2.asStruct.Prio = 1;
 
-                        memcpy(packets2send.back()->payload.packet.header.source, gateway/*from*//*gateway*/, 3);
+                        memcpy(packet->payload.packet.header.source, gateway/*from*//*gateway*/, 3);
                         // if (command.first == 0x14 || command.first == 0x19 || command.first == 0x1e || command.first == 0x2a || command.first == 0x34 || command.first == 0x4a) {
-                        // memcpy(packets2send.back()->payload.packet.header.target, broad, 3);
+                        // memcpy(packet->payload.packet.header.target, broad, 3);
                         // } else {
-                        memcpy(packets2send.back()->payload.packet.header.target, master_to, 3);
+                        memcpy(packet->payload.packet.header.target, master_to, 3);
                         // }
 
-                        //packets2send.back()->delayed = 245;
-                        packets2send.back()->repeatTime = 250; // Slow down discover loop
-                        packets2send.back()->delayed = 250;   // Give enough time for the answer
+                        //packet->delayed = 245;
+                        packet->repeatTime = 250; // Slow down discover loop
+                        packet->delayed = 250;   // Give enough time for the answer
                     }
                     toSend.clear();
                 }

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -235,13 +235,13 @@ namespace IOHC {
         if (radioState == iohcRadio::RadioState::PAYLOAD) {
             // if TX ready?
             if (_flags[0] & RF_IRQFLAGS1_TXREADY) {
-                radio->sent(radio->iohc);
+                radio->sent(radio->packets2send[radio->txCounter]);
                 Radio::clearFlags();
                 if (radioState != iohcRadio::RadioState::TX) {
                     Radio::setRx();
                     radio->setRadioState(iohcRadio::RadioState::RX);
                 }
-                // radio->sent(radio->iohc); // Put after Workaround to permit MQTT sending. No more needed
+                // radio->sent(radio->packets2send[radio->txCounter]); // Put after Workaround to permit MQTT sending. No more needed
                 return;
             }
             // if in RX mode?
@@ -341,7 +341,7 @@ void iohcRadio::startQueuedSend() {
     ets_printf("TX: Preparing %d packet(s)\n", packets2send.size());
     setRadioState(RadioState::TX);
 
-    iohc = packets2send[txCounter];
+    auto packet = packets2send[txCounter];
 
     // 🟢 Set long preamble for first packet
     Radio::setPreambleLength(LONG_PREAMBLE_MS);
@@ -350,18 +350,18 @@ void iohcRadio::startQueuedSend() {
     // Send first packet immediately
     Radio::setStandby();
     Radio::clearFlags();
-    Radio::writeBytes(REG_FIFO, iohc->payload.buffer, iohc->buffer_length);
+    Radio::writeBytes(REG_FIFO, packet->payload.buffer, packet->buffer_length);
     Radio::setTx();
     //packetStamp = esp_timer_get_time();
-    //iohc->decode(true); //false);
-    //IOHC::lastSendCmd = iohc->payload.packet.header.cmd;
+    //packet->decode(true); //false);
+    //IOHC::lastSendCmd = packet->payload.packet.header.cmd;
 
     ets_printf("TX: Sent first packet at %llu us\n", esp_timer_get_time());
 
-    if (iohc->repeat > 0) iohc->repeat--;
+    if (packet->repeat > 0) packet->repeat--;
 
     // Start ticker for repeats (short preamble)
-    Sender.attach_ms(iohc->repeatTime, &iohcRadio::onTxTicker, (void*)this);
+    Sender.attach_ms(packet->repeatTime, &iohcRadio::onTxTicker, (void*)this);
 }
 
 void iohcRadio::send(iohcPacket *packet) {
@@ -378,6 +378,7 @@ void iohcRadio::send(std::vector<iohcPacket *> &iohcTx) {
  
 void iohcRadio::onTxTicker(void *arg) {
     iohcRadio *radio = (iohcRadio *)arg;
+    auto packet = radio->packets2send[radio->txCounter];
 
     // 🩵 Fallback: Check IRQFLAGS2 (0x3F) for PacketSent in FSK mode
     uint8_t irqFlags2 = Radio::readByte(0x3F); // REG_IRQFLAGS2
@@ -410,17 +411,17 @@ void iohcRadio::onTxTicker(void *arg) {
     ESP_LOGD("RADIO", "TXDONE flag set, ready to send repeat or next packet.\n");
 
     // 🔁 Repeat logic
-    if (radio->iohc->repeat > 0) {
-        radio->iohc->repeat--;
-        ets_printf("TX: Repeating current packet (%d repeats left)\n", radio->iohc->repeat);
+    if (packet->repeat > 0) {
+        packet->repeat--;
+        ets_printf("TX: Repeating current packet (%d repeats left)\n", packet->repeat);
     } else {
         radio->txCounter++;
         if (radio->txCounter < radio->packets2send.size()) {
-            radio->iohc = radio->packets2send[radio->txCounter];
+            packet = radio->packets2send[radio->txCounter];
             ets_printf("TX: Moving to next packet %d/%d (repeat=%d)\n",
                        radio->txCounter + 1,
                        radio->packets2send.size(),
-                       radio->iohc->repeat);
+                       packet->repeat);
         }
     }
 
@@ -443,11 +444,11 @@ void iohcRadio::onTxTicker(void *arg) {
     Radio::setPreambleLength(SHORT_PREAMBLE_MS);
     Radio::setStandby();
     Radio::clearFlags();
-    Radio::writeBytes(REG_FIFO, radio->iohc->payload.buffer, radio->iohc->buffer_length);
+    Radio::writeBytes(REG_FIFO, packet->payload.buffer, packet->buffer_length);
     Radio::setTx();
     //packetStamp = esp_timer_get_time();
-    //radio->iohc->decode(true); //false);
-    //IOHC::lastSendCmd = radio->iohc->payload.packet.header.cmd;
+    //packet->decode(true); //false);
+    //IOHC::lastSendCmd = packet->payload.packet.header.cmd;
 
     ets_printf("TX: Sent packet %d/%d at %llu us\n",
                radio->txCounter + 1,

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -364,6 +364,11 @@ void iohcRadio::startQueuedSend() {
     Sender.attach_ms(iohc->repeatTime, &iohcRadio::onTxTicker, (void*)this);
 }
 
+void iohcRadio::send(iohcPacket *packet) {
+    std::vector<iohcPacket *> packets = { packet };
+    send(packets);
+}
+
 void iohcRadio::send(std::vector<iohcPacket *> &iohcTx) {
     queueSend(iohcTx);
     startQueuedSend();

--- a/src/iohcRemote1W.cpp
+++ b/src/iohcRemote1W.cpp
@@ -152,11 +152,12 @@ namespace IOHC {
         switch (cmd) {
             case RemoteButton::Pair: {
                 // 0x2e: 0x1120 + target broadcast + source + 0x2e00 + sequence + hmac
-                packets2send.clear();
 
+                std::vector<iohcPacket *> packets2send;
 //                for (auto&r: remotes) {
 
                     auto* packet = new iohcPacket;
+                    packets2send.push_back(packet);
                     IOHC::iohcRemote1W::forgePacket(packet, r.type[0]);
                     // Packet length
                     packet->payload.packet.header.CtrlByte1.asStruct.MsgLen += sizeof(_p0x2e);
@@ -184,7 +185,6 @@ namespace IOHC {
 
                     packet->buffer_length = packet->payload.packet.header.CtrlByte1.asStruct.MsgLen + 1;
 
-                    packets2send.push_back(packet);
                     // if (typn) packet->payload.packet.header.CtrlByte2.asStruct.LPM = 0; //TODO only first is LPM
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 //                }
@@ -200,12 +200,13 @@ namespace IOHC {
 
             case RemoteButton::Remove: {
                 // 0x39: 0x1c00 + target broadcast + source + 0x3900 + sequence + hmac
-                packets2send.clear();
 
+                std::vector<iohcPacket *> packets2send;
 //                for (auto&r: remotes) {
 
 
                     auto* packet = new iohcPacket;
+                    packets2send.push_back(packet);
                     IOHC::iohcRemote1W::forgePacket(packet, r.type[0]);
                     // Packet length
                     //                    packet->payload.packet.header.CtrlByte1.asStruct.MsgLen = sizeof(_header) - 1;
@@ -233,7 +234,6 @@ namespace IOHC {
 
                     packet->buffer_length = packet->payload.packet.header.CtrlByte1.asStruct.MsgLen + 1;
 
-                    packets2send.push_back(packet);
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 //                }
                 _radioInstance->send(packets2send);
@@ -249,11 +249,12 @@ namespace IOHC {
 
             case RemoteButton::Add: {
                 // 0x30: 0x1100 + target broadcast + source + 0x3000 + ???
-                packets2send.clear();
 
+                std::vector<iohcPacket *> packets2send;
 //                for (auto&r: remotes) {
 
                     auto* packet = new iohcPacket;
+                    packets2send.push_back(packet);
                     IOHC::iohcRemote1W::forgePacket(packet, r.type[0]);
                     // Packet length
                     packet->payload.packet.header.CtrlByte1.asStruct.MsgLen += sizeof(_p0x30);
@@ -282,7 +283,7 @@ namespace IOHC {
 
                     packet->buffer_length = packet->payload.packet.header.CtrlByte1.asStruct.MsgLen + 1;
 
-                    packets2send.push_back(packet);
+
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 //                }
                 _radioInstance->send(packets2send);
@@ -293,12 +294,14 @@ namespace IOHC {
                 break;
             }
            default: {
-                packets2send.clear();
-
                 // 0x00: 0x1600 + target broadcast + source + 0x00 + Originator + ACEI + Main Param + FP1 + FP2 + sequence + hmac
+
+                std::vector<iohcPacket *> packets2send;
 //                for (auto&r: remotes) {
 
                     auto* packet = new iohcPacket;
+                    packets2send.push_back(packet);
+
                     IOHC::iohcRemote1W::forgePacket(packet, r.type[0]);
                     // Packet length
                     // packet->payload.packet.header.CtrlByte1.asStruct.MsgLen += sizeof(_p0x00);
@@ -628,15 +631,15 @@ Every 9 -> 0x20 12:41:28.171 > (23) 1W S 1 E 1  FROM B60D1A TO 00003F CMD 20 <  
                     // }
                     packet->buffer_length = packet->payload.packet.header.CtrlByte1.asStruct.MsgLen + 1;
 
-                    packets2send.push_back(packet);
                     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
+
+                    _radioInstance->send(packets2send);
+
+                    display1WAction(r.node, remoteButtonToString(cmd), "TX", r.name.c_str());
+                    Serial.printf("%s position: %.0f%%\n", r.name.c_str(), r.positionTracker.getPosition());
+                    display1WPosition(r.node, r.positionTracker.getPosition(), r.name.c_str());
+                    break;
                 }
-                _radioInstance->send(packets2send);
-                display1WAction(r.node, remoteButtonToString(cmd), "TX", r.name.c_str());
-                Serial.printf("%s position: %.0f%%\n", r.name.c_str(), r.positionTracker.getPosition());
-                display1WPosition(r.node, r.positionTracker.getPosition(), r.name.c_str());
-                break;
-//            }
         }
         this->save(); // Save sequence number
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,9 +71,6 @@ uint8_t keyCap[16] = {};
 IOHC::iohcRadio *radioInstance;
 IOHC::iohcPacket *radioPackets[IOHC_INBOUND_MAX_PACKETS];
 
-std::vector<IOHC::iohcPacket *> packets2send{};
-std::vector<IOHC::iohcPacket *> packets2send_tmp{};
-
 uint8_t nextPacket = 0;
 
 IOHC::iohcSystemTable *sysTable;
@@ -225,7 +222,6 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
             // 0x0b OverKiz 0x0c Atlantic
             std::vector<uint8_t> toSend = {0xff, 0xc0, 0xba, 0x11, 0xad, 0x0b, 0xcc, 0x00, 0x00};
 
-            packets2send.clear();
             auto* packet = new iohcPacket;
             forgePacket(packet, toSend);
 
@@ -238,9 +234,8 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
             packet->delayed = 250;
             packet->repeat = 0;
 
-            packets2send.push_back(packet);
             digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-            radioInstance->send(packets2send);
+            radioInstance->send(packet);
             break;
         }
         case iohcDevice::RECEIVED_DISCOVER_ANSWER_0x29: {
@@ -260,22 +255,21 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
             // std::vector<uint8_t> toSend = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06}; // 38
             std::vector<uint8_t> toSend = {}; // SEND_DISCOVER_ACTUATOR_0x2C
 
-            packets2send.clear();
-            packets2send.push_back(new IOHC::iohcPacket);
-            forgePacket(packets2send.back(), toSend);
+            auto* packet = new iohcPacket;
+            forgePacket(packet, toSend);
 
-            // packets2send.back()->payload.packet.header.cmd = 0x38;
-            packets2send.back()->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_ACTUATOR_0x2C;
+            // packet->payload.packet.header.cmd = 0x38;
+            packet->payload.packet.header.cmd = iohcDevice::SEND_DISCOVER_ACTUATOR_0x2C;
             // cozyDevice2W->memorizeSend.memorizedData = toSend;
             // cozyDevice2W->memorizeSend.memorizedCmd = SEND_DISCOVER_ACTUATOR_0x2C;
 
             /* Swap */
-            memcpy(packets2send.back()->payload.packet.header.source, iohc->payload.packet.header.target, 3);
-            memcpy(packets2send.back()->payload.packet.header.target, iohc->payload.packet.header.source, 3);
+            memcpy(packet->payload.packet.header.source, iohc->payload.packet.header.target, 3);
+            memcpy(packet->payload.packet.header.target, iohc->payload.packet.header.source, 3);
 
-            packets2send.back()->repeat = 1;
+            packet->repeat = 1;
 
-            radioInstance->send(packets2send);
+            radioInstance->send(packet);
             digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
             break;
         }
@@ -291,20 +285,19 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
 
             std::vector<uint8_t> toSend = {};
 
-            packets2send.clear();
-            packets2send.push_back(new IOHC::iohcPacket);
-            forgePacket(packets2send.back(), toSend);
+            auto* packet = new iohcPacket;
+            forgePacket(packet, toSend);
 
-            packets2send.back()->payload.packet.header.cmd = IOHC::iohcDevice::SEND_DISCOVER_ACTUATOR_ACK_0x2D;
+            packet->payload.packet.header.cmd = IOHC::iohcDevice::SEND_DISCOVER_ACTUATOR_ACK_0x2D;
 
             /* Swap */
-            memcpy(packets2send.back()->payload.packet.header.source, iohc->payload.packet.header.target, 3);
-            memcpy(packets2send.back()->payload.packet.header.target, iohc->payload.packet.header.source, 3);
+            memcpy(packet->payload.packet.header.source, iohc->payload.packet.header.target, 3);
+            memcpy(packet->payload.packet.header.target, iohc->payload.packet.header.source, 3);
 
-            packets2send.back()->delayed = 250;
-            packets2send.back()->repeat = 0;
+            packet->delayed = 250;
+            packet->repeat = 0;
 
-            radioInstance->send(packets2send);
+            radioInstance->send(packet);
             digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
             break;
         }
@@ -343,20 +336,19 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
             std::vector<uint8_t> toSend;
             toSend.assign(encrypted_key, encrypted_key + 16);
 
-            packets2send.clear();
-            packets2send.push_back(new IOHC::iohcPacket);
-            forgePacket(packets2send.back(), toSend);
+            auto* packet = new iohcPacket;
+            forgePacket(packet, toSend);
 
-            packets2send.back()->payload.packet.header.cmd = IOHC::iohcDevice::SEND_KEY_TRANSFERT_0x32;
+            packet->payload.packet.header.cmd = IOHC::iohcDevice::SEND_KEY_TRANSFERT_0x32;
             cozyDevice2W->memorizeSend.memorizedCmd = IOHC::iohcDevice::SEND_KEY_TRANSFERT_0x32;
 
             /* Swap */
-            memcpy(packets2send.back()->payload.packet.header.source, iohc->payload.packet.header.target, 3);
-            memcpy(packets2send.back()->payload.packet.header.target, iohc->payload.packet.header.source, 3);
+            memcpy(packet->payload.packet.header.source, iohc->payload.packet.header.target, 3);
+            memcpy(packet->payload.packet.header.target, iohc->payload.packet.header.source, 3);
 
-            packets2send.back()->repeat = 0;
+            packet->repeat = 0;
 
-            radioInstance->send(packets2send);
+            radioInstance->send(packet);
             digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
             break;
         }
@@ -404,10 +396,9 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
                 std::vector<uint8_t> IVdata = cozyDevice2W->memorizeSend.memorizedData;
                 IVdata.insert(IVdata.begin(), cozyDevice2W->memorizeSend.memorizedCmd);
 
-                packets2send.clear();
-                packets2send.push_back(new IOHC::iohcPacket);
+                auto* packet = new iohcPacket;
 
-                packets2send.back()->payload.packet.header.cmd = IOHC::iohcDevice::SEND_CHALLENGE_ANSWER_0x3D;
+                packet->payload.packet.header.cmd = IOHC::iohcDevice::SEND_CHALLENGE_ANSWER_0x3D;
 
                 unsigned char initial_value[16];
                 constructInitialValue(IVdata, initial_value, IVdata.size(), challengeAsked, nullptr);
@@ -415,7 +406,7 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
                 uint8_t dataLen = 6;
 
                 if (cozyDevice2W->memorizeSend.memorizedCmd == IOHC::iohcDevice::RECEIVED_ASK_CHALLENGE_0x31) {
-                    packets2send.back()->payload.packet.header.cmd = IOHC::iohcDevice::SEND_KEY_TRANSFERT_0x32;
+                    packet->payload.packet.header.cmd = IOHC::iohcDevice::SEND_KEY_TRANSFERT_0x32;
                     dataLen = 16;
                     IVdata = {IOHC::iohcDevice::RECEIVED_ASK_CHALLENGE_0x31};
                     constructInitialValue(IVdata, initial_value, 1, challengeAsked, nullptr);
@@ -428,22 +419,22 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
 
                 std::vector<uint8_t> toSend;
                 toSend.assign(initial_value, initial_value + dataLen);
-                forgePacket(packets2send.back(), toSend);
+                forgePacket(packet, toSend);
 
                 /* Swap */
-                memcpy(packets2send.back()->payload.packet.header.source, iohc->payload.packet.header.target, 3);
-                memcpy(packets2send.back()->payload.packet.header.target, iohc->payload.packet.header.source, 3);
+                memcpy(packet->payload.packet.header.source, iohc->payload.packet.header.target, 3);
+                memcpy(packet->payload.packet.header.target, iohc->payload.packet.header.source, 3);
 
-                packets2send.back()->repeatTime = 6;
-                packets2send.back()->repeat = 1;
+                packet->repeatTime = 6;
+                packet->repeat = 1;
 
-                radioInstance->send(packets2send);
+                radioInstance->send(packet);
 
                 // Serial.print("IV used for key encryption: ");
                 // for (int i = 0; i < 16; i++)
                 //     Serial.printf("%02X ", initial_value[i]);
                 // Serial.println();
-                printf("Challenge response %2.2X: ", packets2send[0]->payload.packet.header.cmd);
+                printf("Challenge response %2.2X: ", packet->payload.packet.header.cmd);
                 for (int i = 0; i < dataLen; i++)
                     printf("%02X ", initial_value[i]);
                 printf("\n");
@@ -496,20 +487,20 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
             std::vector<uint8_t> toSend = {0x4d, 0x59, 0x5f, 0x47, 0x41, 0x54, 0x45, 0x57, 0x41, 0x59};
             toSend.resize(16);
             
-            packets2send.clear();
-            packets2send.push_back(new IOHC::iohcPacket);
-            forgePacket(packets2send.back(), toSend);
+            auto* packet = new iohcPacket;
 
-            packets2send.back()->payload.packet.header.cmd = 0x51;
+            forgePacket(packet, toSend);
+
+            packet->payload.packet.header.cmd = 0x51;
 
             /* Swap */
-            memcpy(packets2send.back()->payload.packet.header.source, cozyDevice2W->gateway, 3);
-            memcpy(packets2send.back()->payload.packet.header.target, iohc->payload.packet.header.source, 3);
+            memcpy(packet->payload.packet.header.source, cozyDevice2W->gateway, 3);
+            memcpy(packet->payload.packet.header.target, iohc->payload.packet.header.source, 3);
 
-            packets2send.back()->delayed = 50;
-            packets2send.back()->repeat = 0;
+            packet->delayed = 50;
+            packet->repeat = 0;
 
-            radioInstance->send(packets2send);
+            radioInstance->send(packet);
             digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
             }
             break;
@@ -703,20 +694,18 @@ void txUserBuffer(Tokens *cmd) {
         return;
     }
     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
-    if (!packets2send[0])
-        packets2send[0] = new IOHC::iohcPacket;
+    auto *packet = new iohcPacket;
 
     if (cmd->size() == 3)
-        packets2send[0]->frequency = frequencies[atoi(cmd->at(2).c_str()) - 1];
+        packet->frequency = frequencies[atoi(cmd->at(2).c_str()) - 1];
     else
-        packets2send[0]->frequency = 0;
+        packet->frequency = 0;
 
-    packets2send[0]->buffer_length = hexStringToBytes(cmd->at(1), packets2send[0]->payload.buffer);
-    packets2send[0]->repeatTime = 35;
-    packets2send[0]->repeat = 1;
-    packets2send[1] = nullptr;
+    packet->buffer_length = hexStringToBytes(cmd->at(1), packet->payload.buffer);
+    packet->repeatTime = 35;
+    packet->repeat = 1;
 
-    radioInstance->send(packets2send);
+    radioInstance->send(packet);
     digitalWrite(RX_LED, digitalRead(RX_LED) ^ 1);
 }
 


### PR DESCRIPTION
This are quite some changes, but mainly a simple pattern: instead of using a (reusable) field to store packets in temporarily before sending, use a local variable or send a single package. Benefit: there is never an interaction between multiple send actions in multiple threads that might impact each-other. And additional benefit is that the code becomes simpler.

Second change is slightly more specific, but same pattern: don't use the same field (`iohc`) for both receiving and sending packets. As changing the receive side to a local variable is much more involved, I left that path using the field for now. Sending a packet now uses a local variable (but I did it only for the only path that is still used).

These changes should not change any behavior, just the above mentioned mechanisms.