### PR TITLE
Loose ends

### DIFF
--- a/include/oled_display.h
+++ b/include/oled_display.h
@@ -29,6 +29,7 @@ void updateDisplayStatus();
 #else
 inline bool initDisplay() { return true; }
 inline void display1WAction(const uint8_t *, const char *, const char *, const char * = nullptr) {}
+inline void display1WPosition(const uint8_t *, float , const char * = nullptr) {}
 inline void updateDisplayStatus() {}
 inline void displayCustomMessage(const char*, const char* = nullptr) {}
 inline void clearDisplayMessages() {}

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -26,6 +26,8 @@
 inline const char *wifi_ssid = "";
 inline const char *wifi_passwd = "";
 
+#define REQUIRE_MINIMUM_WPA2_PSK        // Comment out to enable WEP/WPA1
+
 #define MQTT
 
 // Default MQTT configuration. These values can be changed at runtime through


### PR DESCRIPTION
Mini PR to address two small things:
1. Compilation with #define Adafruit_SSD1306 off
2. Set default minimum WiFi authentication to WPA2-PSK (to be a bit more secure and malicious people can't easily take over the device)