### PR TITLE
Esp32c3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 <img src="https://github.com/user-attachments/assets/f6b606a1-0eca-4fd6-a509-d5d1136b2d31" alt="smlogo" width="50"/>
 
+# ESP32C3 + SX127x Test
+
+### 🔌 Pin-Belegung: ESP32-C3 ➔ SX127x (ohne Display)
+
+| ESP32-C3 (GPIO) | SX127x / RFM95 | Kategorie | Beschreibung |
+| :--- | :--- | :--- | :--- |
+| **3V3** | **3.3V / VCC** | ⚡ Strom | Versorgungsspannung (Max. 3.6V, niemals an 5V anschließen!) |
+| **GND** | **GND** | ⚡ Strom | Masse |
+| **GPIO 4** | **SCK / SCLK** | 📡 SPI | Serial Clock |
+| **GPIO 5** | **MISO** | 📡 SPI | Master In Slave Out |
+| **GPIO 6** | **MOSI** | 📡 SPI | Master Out Slave In |
+| **GPIO 7** | **NSS / CS** | 📡 SPI | Chip Select |
+| **GPIO 8** | **RST** | ⚙️ Steuerung | Reset des Moduls |
+| **GPIO 9** | **DIO0** | ⚙️ Interrupt | Rx/Tx Status (Sehr wichtig für den Empfang von Paketen) |
+| **GPIO 10** | **DIO1** | ⚙️ Interrupt | Rx Timeout / Status |
+| **GPIO 20** | **DIO2** | ⚙️ Interrupt | FSK/OOK Steuerung / Status |
+
+> **⚠️ Wichtiger Hinweis:** Schraube unbedingt die Antenne an das LoRa-Modul, **bevor** du den ESP32-C3 an den Strom (bzw. USB) anschließt! Ein Sendeversuch ohne angeschlossene Antenne kann die Sende-Endstufe auf dem Chip zerstören.
+
 # IO-Homecontrol ESP32 Project
 
 Based on the wonderful work of:

--- a/include/board-config.h
+++ b/include/board-config.h
@@ -56,6 +56,20 @@
 #define RADIO_DIO1_PIN      35 //HELTEC
 #define RADIO_DIO2_PIN      34 //HELTEC
 #define RADIO_BUSY_PIN      32
+// ---> NEU: HIER DEN C3 BLOCK EINFÜGEN <---
+#elif defined(ESP32C3)
+// Achtung: C3 hat nur GPIO 0-21. Pins 12-17 sind absolut verboten (Flash)!
+// Passe diese Pins an deine tatsächliche Verkabelung an:
+#define RADIO_SCLK_PIN       4
+#define RADIO_MISO_PIN       5
+#define RADIO_MOSI_PIN       6
+#define RADIO_CS_PIN         7
+#define RADIO_DIO0_PIN       9
+#define RADIO_RST_PIN        8
+#define BOARD_LED_PIN        2  // Oft die interne LED bei C3 DevKits
+#define RADIO_DIO1_PIN       10
+#define RADIO_DIO2_PIN       20
+#define RADIO_BUSY_PIN       21 // (Falls benötigt, sonst weglassen)
 #else
 #define RADIO_SCLK_PIN       5
 #define RADIO_MISO_PIN      19
@@ -79,6 +93,11 @@
 #define I2C_SDA_PIN 4
 #define I2C_SCL_PIN 15
 #define DISPLAY_OLED_RST_PIN 16
+// ---> NEU: HIER DEN C3 BLOCK EINFÜGEN <---
+#elif defined(ESP32C3)
+#define I2C_SDA_PIN 1
+#define I2C_SCL_PIN 3
+#define DISPLAY_OLED_RST_PIN -1 // Die meisten C3 Setups haben keinen Hardware-Reset fürs OLED
 #else
 #define I2C_SDA_PIN 21
 #define I2C_SCL_PIN 22

--- a/include/board-config.h
+++ b/include/board-config.h
@@ -133,7 +133,7 @@
 #define RADIO_PREAMBLE_DETECTED                 RADIO_DIO_4     // Preamble detected from Radio (used instead of FIFO empty)
 #endif
 
-#define SPI_CLK_FRQ                                 10000000
+#define SPI_CLK_FRQ                                 1000000
 
 /*
  * Defines the time required for the TCXO to wakeup [ms].

--- a/platformio.ini
+++ b/platformio.ini
@@ -147,14 +147,20 @@ board = esp32-c3-devkitm-1
 board_build.mcu = esp32c3
 board_build.f_cpu = 160000000L
 board_build.partitions = huge_app.csv
+upload_speed = 115200
 build_unflags =
     -std=gnu++11
     -Os
+	; WICHTIG: Entfernt das Core-1 Pinning aus dem common-Block!
+    -DCONFIG_ESP_WIFI_TASK_PINNED_TO_CORE_1=y
 build_flags =
     -D ESP32C3 ; Falls du im Code via #ifdef ESP32C3 spezifische Pins setzen musst
     ; Diese beiden Zeilen sind entscheidend für den C3 Serial Output via USB:
     -D ARDUINO_USB_MODE=1
     -D ARDUINO_USB_CDC_ON_BOOT=1
+	; WICHTIG: Ersetzt es durch das korrekte Core-0 Pinning!
+    -DCONFIG_ESP_WIFI_TASK_PINNED_TO_CORE_0=y
+	-D WIFI_AUTH_WPA2_PSK_ONLY
     ; WICHTIG: Die globalen Projekt-Flags laden!
     ${common.build_flags}
     ${extra.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,7 @@ lib_deps_builtin =
 lib_deps_external =
 ;	WiFiManager=
 build_flags =
-	!python3 git_rev_macro.py
+	!python3 git_rev_macro.py || python git_rev_macro.py
 	-DDEBUG
 	-DCORE_DEBUG_LEVEL=5  ; 3=ERROR, 4=WARN, 5=DEBUG, 6=VERBOSE
 ;	-DCONFIG_FREERTOS_HZ=1000
@@ -140,3 +140,21 @@ build_flags =
 	${extra.build_flags}
 
 #extra_scripts = ${common.extra_scripts}
+
+[env:esp32c3]
+board = esp32-c3-devkitm-1
+; MCU Settings
+board_build.mcu = esp32c3
+board_build.f_cpu = 160000000L
+board_build.partitions = huge_app.csv
+build_unflags =
+    -std=gnu++11
+    -Os
+build_flags =
+    -D ESP32C3 ; Falls du im Code via #ifdef ESP32C3 spezifische Pins setzen musst
+    ; Diese beiden Zeilen sind entscheidend für den C3 Serial Output via USB:
+    -D ARDUINO_USB_MODE=1
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    ; WICHTIG: Die globalen Projekt-Flags laden!
+    ${common.build_flags}
+    ${extra.build_flags}

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -96,7 +96,15 @@ namespace IOHC {
         // Notify de RX state machine
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
         vTaskNotifyGiveFromISR(handle_interrupt, &xHigherPriorityTaskWoken);
+        #if defined(ESP32C3)
+        // RISC-V Architektur (ESP32-C3): Makro nimmt keine Argumente
+        if (xHigherPriorityTaskWoken == pdTRUE) {
+            portYIELD_FROM_ISR();
+        }
+        #else
+        // Xtensa Architektur (Heltec / LilyGo): Klassischer Aufruf mit Argument
         portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+        #endif
     }
 
     void callbackTaskLoop(void *parameters) {

--- a/src/iohcRadio.cpp
+++ b/src/iohcRadio.cpp
@@ -70,10 +70,12 @@ namespace IOHC {
      * the interrupt service routine is complete.
      */
     void IRAM_ATTR handle_interrupt_fromisr() {
+
+        if (handle_interrupt == NULL) return;
         bool preamble = digitalRead(RADIO_PREAMBLE_DETECTED);
         bool payload = digitalRead(RADIO_PACKET_AVAIL);
         iohcRadio::txComplete = true;
-        ets_printf("TX: TX-RX DONE detected, flag set\n");
+        //ets_printf("TX: TX-RX DONE detected, flag set\n");
 
 
         if (payload) {
@@ -150,6 +152,9 @@ namespace IOHC {
             return;
         }
 
+        printf("Waiting for stabilization...\n");
+        delay(500); // 5 Sekunden Pause zum Stabilisieren
+ 
         // start state machine
         printf("Starting Interrupt Handler...\n");
         BaseType_t task_code = xTaskCreatePinnedToCore(handle_interrupt_task, "handle_interrupt_task", 8192,
@@ -223,6 +228,10 @@ namespace IOHC {
  * scenarios:
  */
     void IRAM_ATTR iohcRadio::tickerCounter(iohcRadio *radio) {
+
+    // Sicherung: Verhindere Zugriff, wenn das Objekt noch nicht bereit ist
+    if (radio == nullptr) return;
+
         // Not need to put in IRAM as we reuse task for µs instead ISR
 #if defined(RADIO_SX127X)
         Radio::readBytes(REG_IRQFLAGS1, _flags, sizeof(_flags));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,6 +97,10 @@ int log_to_buffer_and_serial(const char *format, va_list args) {
 
 void setup() {
 
+    #ifdef ESP32C3
+    delay(2000); 
+    #endif
+
     Serial.begin(115200);       //Start serial connection for debug and manual input
     esp_log_set_vprintf(log_to_buffer_and_serial);
     esp_log_level_set("*", ESP_LOG_DEBUG);    // Or VERBOSE for ESP_LOGV

--- a/src/mqtt_handler.cpp
+++ b/src/mqtt_handler.cpp
@@ -383,7 +383,7 @@ void connectToMqtt() {
         return;
     }
     if (mqtt_server.empty()) {
-        Serial.println("MQTT server not configured");
+        //Serial.println("MQTT server not configured");
         return;
     }
     s_lastMqttConnectAttemptMs = millis();

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -27,6 +27,9 @@
 #include <ESPmDNS.h>
 #include <TickerUsESP32.h>
 #include <tuple>
+#ifdef ESP32C3
+#include "esp_wifi.h"
+#endif
 
 const long PORTAL_TIMEOUT = 300000; // 5 minuten = 300.000 ms
 const uint32_t WIFI_NOTIFY_GOT_IP = BIT0;
@@ -138,6 +141,16 @@ static void applyAdvancedWiFiSettings() {
         // Enable minimal WPA2_PSK level (also allows WPA3 or other more secure modes)
         config.sta.threshold.authmode = WIFI_AUTH_WPA_PSK; 
 #endif // REQUIRE_MINIMUM_WPA2_PSK
+
+// --- HIER FEHLTE NOCH DER FRITZBOX-SICHERHEITS-FIX ---
+#ifdef ESP32C3
+        // FritzBox Kompatibilitäts-Fix für den C3
+        config.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
+        config.sta.pmf_cfg.capable = false;
+        config.sta.pmf_cfg.required = false;
+#endif
+        // -----------------------------------------------------
+
         esp_wifi_set_config(WIFI_IF_STA, &config);
     }
 }
@@ -149,6 +162,15 @@ static std::string getConfiguredSSID() {
     }
 
     return std::string(reinterpret_cast<const char*>(conf.sta.ssid));
+}
+
+// --- NEU: Diese Funktion holt das Passwort sauber aus dem Speicher ---
+static std::string getConfiguredPassword() {
+    wifi_config_t conf {};
+    if (esp_wifi_get_config(WIFI_IF_STA, &conf) != ESP_OK) {
+        return {};
+    }
+    return std::string(reinterpret_cast<const char*>(conf.sta.password));
 }
 
 static void triggerWiFiReconnect() {
@@ -172,6 +194,12 @@ static void runConfigPortal(const std::string& ssid, bool hasWifiConfiguration) 
         Serial.println("WiFi: No WiFi network configured, opening Config Portal...");
     }
 
+    #ifdef ESP32C3
+    // C3 AP-Wakeup Fix
+    WiFi.setSleep(false);
+    WiFi.mode(WIFI_AP_STA);
+    #endif
+
     WiFiManager wm;
 
     applyAdvancedWiFiSettings();
@@ -179,6 +207,16 @@ static void runConfigPortal(const std::string& ssid, bool hasWifiConfiguration) 
     wm.setDisableConfigPortal(true); // allow config portal shutdown when previous configured wifi comes available.
     wm.setConfigPortalTimeout(PORTAL_TIMEOUT / 1000);
     wm.autoConnect("iohc-setup");
+
+#ifdef ESP32C3
+    // 1. Verhindere RF-Absturz durch zu viel Strombedarf
+    WiFi.setTxPower(WIFI_POWER_8_5dBm);
+    
+    // 2. Zwinge nun auch explizit das Access-Point-Interface (WIFI_IF_AP) in den Legacy-Modus!
+    // (Der WiFiManager hat das beim Starten sonst wieder auf 802.11n überschrieben)
+    esp_wifi_set_protocol(WIFI_IF_AP, WIFI_PROTOCOL_11B | WIFI_PROTOCOL_11G);
+    esp_wifi_set_bandwidth(WIFI_IF_AP, WIFI_BW_HT20);
+#endif
 
     const unsigned long portalStartTime = millis();
     bool portalClosed = false;
@@ -225,11 +263,24 @@ static void wifiWorker(void * pvParameters) {
     wl_status_t status = WL_DISCONNECTED;
 
     WiFi.mode(WIFI_STA);
+    
+// 1. ZUERST den sauberen Zustand herstellen
+    #ifdef ESP32C3
+        WiFi.setSleep(false);
+        WiFi.setTxPower(WIFI_POWER_8_5dBm);
+        esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11B | WIFI_PROTOCOL_11G);
+        esp_wifi_set_bandwidth(WIFI_IF_STA, WIFI_BW_HT20);
+        WiFi.disconnect(true, false);
+        delay(100);
+    #endif
 
     const std::string ssid = getConfiguredSSID();
     const bool hasWifiConfiguration = !ssid.empty();
+    
     if (hasWifiConfiguration) {
         applyAdvancedWiFiSettings();
+        
+        // Das Original: Verbindet sich mit den Tresor-Daten
         WiFi.begin();
 
         Serial.printf("WiFi: Attempt connection to '%s', try for max 30 seconds...\n", ssid.c_str());
@@ -287,7 +338,11 @@ void initWifi() {
     // including after auto-reconnects where the connect task never runs.
     WiFi.setHostname("MiOpenIO");
 
-    xTaskCreatePinnedToCore(wifiWorker, "WiFi_Worker", 8192, NULL, 3, &wifiWorkerTaskHandle, 1);
+    #ifdef ESP32C3
+        xTaskCreatePinnedToCore(wifiWorker, "WiFi_Worker", 8192, NULL, 3, &wifiWorkerTaskHandle, 0);
+    #else
+        xTaskCreatePinnedToCore(wifiWorker, "WiFi_Worker", 8192, NULL, 3, &wifiWorkerTaskHandle, 1);
+    #endif
 
     WiFi.onEvent(onWiFiEvent);
     WiFi.setAutoReconnect(true);

--- a/src/wifi_helper.cpp
+++ b/src/wifi_helper.cpp
@@ -91,6 +91,11 @@ static void handleWifiConnected() {
         wifiStatus.rssi = WiFi.RSSI();
         wifiStatus.signalStrengthPercent = rssiToQuality(wifiStatus.rssi);
 
+        if (WiFi.getMode() == WIFI_AP_STA) {
+            Serial.println("WiFi: Verbindung steht. Schalte AP-Modus aus.");
+            WiFi.mode(WIFI_STA);
+        }
+
         wifiReconnectTimer.detach();
         rssiTimer.attach(5, rssiTimerCb);
         updateDisplayStatus();


### PR DESCRIPTION
Implementig Version with ESP32 C3:
I can´t commit to your wiki thats why I update readme for connection:

# ESP32C3 + SX127x Test

### 🔌 Pin-Belegung: ESP32-C3 ➔ SX127x (ohne Display)

| ESP32-C3 (GPIO) | SX127x / RFM95 | Kategorie | Beschreibung |
| :--- | :--- | :--- | :--- |
| **3V3** | **3.3V / VCC** | ⚡ Strom | Versorgungsspannung (Max. 3.6V, niemals an 5V anschließen!) |
| **GND** | **GND** | ⚡ Strom | Masse |
| **GPIO 4** | **SCK / SCLK** | 📡 SPI | Serial Clock |
| **GPIO 5** | **MISO** | 📡 SPI | Master In Slave Out |
| **GPIO 6** | **MOSI** | 📡 SPI | Master Out Slave In |
| **GPIO 7** | **NSS / CS** | 📡 SPI | Chip Select |
| **GPIO 8** | **RST** | ⚙️ Steuerung | Reset des Moduls |
| **GPIO 9** | **DIO0** | ⚙️ Interrupt | Rx/Tx Status (Sehr wichtig für den Empfang von Paketen) |
| **GPIO 10** | **DIO1** | ⚙️ Interrupt | Rx Timeout / Status |
| **GPIO 20** | **DIO2** | ⚙️ Interrupt | FSK/OOK Steuerung / Status |

> **⚠️ Wichtiger Hinweis:** Schraube unbedingt die Antenne an das LoRa-Modul, **bevor** du den ESP32-C3 an den Strom (bzw. USB) anschließt! Ein Sendeversuch ohne angeschlossene Antenne kann die Sende-Endstufe auf dem Chip zerstören.