### PR TITLE
Fix issue with Velux 1W remotes sending additional command packets with open/close buttons

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -461,6 +461,7 @@ bool msgRcvd(IOHC::iohcPacket *iohc) {
                     case 0x0000: action = "OPEN"; break;
                     case 0xC800: action = "CLOSE"; break;
                     case 0xD200: action = "STOP"; break;
+                    case 0xD400: return false; /* MP: Ignore / FP: ReadOnly */
                     case 0xD803: action = "VENT"; break;
                     case 0x6400: action = "FORCE"; break;
                     default: break;


### PR DESCRIPTION
I'm using Velux SSL blinds and their 1W remotes.
 
I encountered the same problem cited in #184 : using the remote updates the linked blind status but transitions from "opening"/"closing" to "stop" when only pressing the open/close button of the remote. This makes the MQTT reporting sloppy and does not update the blind state correctly when using the remote.

## Debug traces
I get the following traces:

### Open / up button: 
```
20:12:29.057 > (22) 1W S 1 E 1 [LPM]    FROM AACB7A TO 00003F CMD 00 +0.000      >  DATA(14)  0161000000006aa61985b0a93dd4      SEQ 6aa6 MAC 1985b0a93dd4  Org 1 Acei 61 Main 0 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:12:29.064 > [BlindPosition] start opening (pos=100.0%)
20:12:29.081 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +24.513     >  DATA(14)  0161000000006aa61985b0a93dd4      SEQ 6aa6 MAC 1985b0a93dd4  Org 1 Acei 61 Main 0 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:12:29.108 > [BlindPosition] update (state=0 pos=100.0%)
20:12:29.108 > [BlindPosition] start opening (pos=100.0%)
20:12:29.108 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +24.357     >  DATA(14)  0161000000006aa61985b0a93dd4      SEQ 6aa6 MAC 1985b0a93dd4  Org 1 Acei 61 Main 0 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:12:29.138 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +24.515     >  DATA(14)  0161000000006aa61985b0a93dd4      SEQ 6aa6 MAC 1985b0a93dd4  Org 1 Acei 61 Main 0 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:12:29.138 > [BlindPosition] update (state=0 pos=100.0%)
20:12:29.138 > [BlindPosition] start opening (pos=100.0%)
20:12:29.199 > (24) 1W S 1 E 1  FROM AACB7A TO 00007F CMD 00 +41.009     >  DATA(16)  0161d40080c800006aa7a23199f11705  SEQ 6aa7 MAC a23199f11705  Org 1 Acei 61 Main D400 fp1 80 fp2 C8 Data    0 Acei 3 0 0 1  Type Venetian blind
20:12:29.200 > [BlindPosition] update (state=0 pos=100.0%)
20:12:29.200 > [BlindPosition] start opening (pos=100.0%)
20:12:29.200 > (24) 1W S 1 E 1  FROM AACB7A TO 00007F CMD 00 +25.253     >  DATA(16)  0161d40080c800006aa7a23199f11705  SEQ 6aa7 MAC a23199f11705  Org 1 Acei 61 Main D400 fp1 80 fp2 C8 Data    0 Acei 3 0 0 1  Type Venetian blind 
20:12:29.224 > (24) 1W S 1 E 1  FROM AACB7A TO 00007F CMD 00 +25.686     >  DATA(16)  0161d40080c800006aa7a23199f11705  SEQ 6aa7 MAC a23199f11705  Org 1 Acei 61 Main D400 fp1 80 fp2 C8 Data    0 Acei 3 0 0 1  Type Venetian blind 
20:12:29.248 > (24) 1W S 1 E 1  FROM AACB7A TO 00007F CMD 00 +24.336     >  DATA(16)  0161d40080c800006aa7a23199f11705  SEQ 6aa7 MAC a23199f11705  Org 1 Acei 61 Main D400 fp1 80 fp2 C8 Data    0 Acei 3 0 0 1  Type Venetian blind
20:12:29.614 > [BlindPosition] update (state=0 pos=100.0%)
20:12:29.614 > [BlindPosition] stop (pos=100.0%)
```

### Close / down button:
```
20:13:08.920 > (22) 1W S 1 E 1 [LPM]    FROM AACB7A TO 00003F CMD 00 +0.000      >  DATA(14)  0161c80000006aaa6c26ad4afef0      SEQ 6aaa MAC 6c26ad4afef0  Org 1 Acei 61 Main C800 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:13:08.971 > [BlindPosition] start closing (pos=100.0%)
20:13:08.971 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +24.833     >  DATA(14)  0161c80000006aaa6c26ad4afef0      SEQ 6aaa MAC 6c26ad4afef0  Org 1 Acei 61 Main C800 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:13:08.971 > [BlindPosition] update (state=2 pos=100.0%)
20:13:08.971 > [BlindPosition] update (state=2 pos=100.0%)
20:13:08.971 > [BlindPosition] start closing ((22) 1W S 1 E 1   FROM AACB7A TO 00003F CMD 00 +24.106     >  DATA(14)  0161c80000006aaa6c26ad4afef0      SEQ 6aaa MAC 6c26ad4afef0  Org 1 Acei 61 Main C800 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:13:08.973 > pos=100.0%)
20:13:08.994 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +24.700     >  DATA(14)  0161c80000006aaa6c26ad4afef0      SEQ 6aaa MAC 6c26ad4afef0  Org 1 Acei 61 Main C800 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:13:09.007 > [BlindPosition] update (state=2 pos=99.9%)
20:13:09.008 > [BlindPosition] update (state=2 pos=99.9%)
20:13:09.008 > [BlindPosition] start closing (pos=99.9%)
20:13:09.043 > [BlindPosition] update (state=2 pos=99.9%)
20:13:09.043 > [BlindPosition] update (state=2 pos=99.9%)
20:13:09.043 > [BlindPosition] start closing (pos=99.9%)
20:13:09.043 > (24) 1W S 1 E 1  FROM AACB7A TO 00007F CMD 00 +40.871     >  DATA(16)  0161d40080c800006aab367de4588317  SEQ 6aab MAC 367de4588317  Org 1 Acei 61 Main D400 fp1 80 fp2 C8 Data    0 Acei 3 0 0 1  Type Venetian blind 
20:13:09.063 > (24) 1W S 1 E 1  FROM AACB7A TO 00007F CMD 00 +25.101     >  DATA(16)  0161d40080c800006aab367de4588317  SEQ 6aab MAC 367de4588317  Org 1 Acei 61 Main D400 fp1 80 fp2 C8 Data    0 Acei 3 0 0 1  Type Venetian blind 
20:13:09.086 > (24) 1W S 1 E 1  FROM AACB7A TO 00007F CMD 00 +24.997     >  DATA(16)  0161d40080c800006aab367de4588317  SEQ 6aab MAC 367de4588317  Org 1 Acei 61 Main D400 fp1 80 fp2 C8 Data    0 Acei 3 0 0 1  Type Venetian blind 
20:13:09.111 > (24) 1W S 1 E 1  FROM AACB7A TO 00007F CMD 00 +25.075     >  DATA(16)  0161d40080c800006aab367de4588317  SEQ 6aab MAC 367de4588317  Org 1 Acei 61 Main D400 fp1 80 fp2 C8 Data    0 Acei 3 0 0 1  Type Venetian blind 
20:13:09.668 > [BlindPosition] update (state=2 pos=98.3%)
20:13:10.688 > [BlindPosition] update (state=2 pos=95.8%)
20:13:11.704 > [BlindPosition] update (state=2 pos=93.3%)
```

### Stop button : 
```
20:13:12.656 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +0.000      >  DATA(14)  0161d20000006aac474412e3fc3d      SEQ 6aac MAC 474412e3fc3d  Org 1 Acei 61 Main D200 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:13:12.690 > [BlindPosition] update (state=2 pos=91.0%)
20:13:12.691 > [BlindPosition] update (state=2 pos=91.0%)
20:13:12.691 > [BlindPosition] stop (pos=91.0%)
20:13:12.691 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +24.512     >  DATA(14)  0161d20000006aac474412e3fc3d      SEQ 6aac MAC 474412e3fc3d  Org 1 Acei 61 Main D200 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:13:12.709 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +24.607     >  DATA(14)  0161d20000006aac474412e3fc3d      SEQ 6aac MAC 474412e3fc3d  Org 1 Acei 61 Main D200 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:13:12.710 > [BlindPosition] stop (pos=91.0%)
20:13:12.735 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +24.356     >  DATA(14)  0161d20000006aac474412e3fc3d      SEQ 6aac MAC 474412e3fc3d  Org 1 Acei 61 Main D200 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:13:12.735 > [BlindPosition] stop (pos=91.0%)
20:13:12.747 > E (824666) Arduino: /1W.json.tmp does not exists or is directory
20:13:12.774 > [BlindPosition] stop (pos=91.0%)
20:13:12.836 > E (824749) Arduino: /1W.json.bak does not exists or is directory
20:13:13.268 > 
20:13:13.287 > (22) 1W S 1 E 1 [LPM]    FROM AACB7A TO 00003F CMD 00 +0.000      >  DATA(14)  0161d20000006aad67b4e33e4b55      SEQ 6aad MAC 67b4e33e4b55  Org 1 Acei 61 Main D200 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:13:13.314 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +24.529     >  DATA(14)  0161d20000006aad67b4e33e4b55      SEQ 6aad MAC 67b4e33e4b55  Org 1 Acei 61 Main D200 fp1 0 fp2 0  Acei [3 0 0 1  Type All 
20:13:13.315 > BlindPosition] stop (pos=91.0%)
20:13:13.336 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +24.476     >  DATA(14)  0161d20000006aad67b4e33e4b55      SEQ 6aad MAC 67b4e33e4b55  Org 1 Acei 61 Main D200 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:13:13.366 > [BlindPosition] stop (pos=91.0%)
20:13:13.366 > (22) 1W S 1 E 1  FROM AACB7A TO 00003F CMD 00 +24.527     >  DATA(14)  0161d20000006aad67b4e33e4b55      SEQ 6aad MAC 67b4e33e4b55  Org 1 Acei 61 Main D200 fp1 0 fp2 0  Acei 3 0 0 1  Type All 
20:13:13.366 > [BlindPosition] stop (pos=91.0%)
20:13:13.459 > [BlindPosition] stop (pos=91.0%)
```

## Root cause
Note that for the open (resp. close) actions, the remote sends 4 0x00 commands with MP=0x0000 (resp. 0xC800), which is expected, but also follows with 4 0x00 commands with **MP=0xD400**. These 0xD400 messages are shown as "unknown", and then interpreted as a `IOHC::RemoteButton::Stop` button in `msgRcvd()`, which triggers this undesirable behavior.

Main parameter value `0xD400` is described as _MP: Ignore / FP: ReadOnly_ in [Velocet's repository commands documentation](https://github.com/Velocet/iown-homecontrol/blob/b7a526d07506f5192548aadfecf68d0f6e5497fa/docs/commands.md), so I guess it's fine to ignore the packet with this MP value.

## Result
The status is reported correctly both when using the remote and MQTT with this fix.